### PR TITLE
Add possibility to add configuration for more than one project

### DIFF
--- a/projects/index.js
+++ b/projects/index.js
@@ -1,0 +1,33 @@
+const fs = require('fs')
+const path = require('path')
+
+function load(project) {
+  const filePath = path.join(__dirname, project + '.json')
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'))
+}
+
+function packinize(obj) {
+  const newObj = {}
+
+  Object.keys(obj).forEach(key => {
+    const value = obj[key]
+
+    let newValue
+    if (typeof value === 'string') {
+      newValue = JSON.stringify(value)
+    } else if (typeof value === 'object') {
+      newValue = packinize(value)
+    } else {
+      newValue = value
+    }
+
+    newObj[key] = newValue
+  })
+
+  return newObj
+}
+
+module.exports = {
+  load,
+  packinize
+}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,9 @@
 const webpack = require('webpack')
 const HtmlWebPackPlugin = require('html-webpack-plugin')
+const projects = require('./projects')
+
+const projectName = process.env.npm_config_project || 'dev'
+const conf = projects.load(projectName)
 
 module.exports = {
   entry: './src/index.js',
@@ -25,6 +29,9 @@ module.exports = {
     new HtmlWebPackPlugin({
       template: './src/index.html',
       filename: './index.html'
+    }),
+    new webpack.DefinePlugin({
+      __CONF__: projects.packinize(conf)
     })
   ],
   devServer: {


### PR DESCRIPTION
- configuration will be written to __CONF__ global
- we want to use different projects for dev, testing, production and
  probably for cypress tests
- use `--project={name}` when app is run to define the project to be
  used
- default project (no --project argument used) is `dev`