### PR TITLE
Add oil uplift field to flight creation dialog

### DIFF
--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -57,6 +57,7 @@
   "flight.create.dialog.fuel": "Treibstoff",
   "flight.create.dialog.fueluplift": "Menge (L)",
   "flight.create.dialog.fueltype": "Typ",
+  "flight.create.dialog.oiluplift": "Öl (L)",
   "flight.create.dialog.buttons.cancel": "Abbrechen",
   "flight.create.dialog.buttons.create": "Speichern",
 

--- a/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
@@ -135,6 +135,7 @@ class FlightCreateDialog extends React.Component {
               </Grid>
             </Grid>
           </FormControl>
+          {this.renderDecimalField('oilUplift')}
         </DialogContent>
         <DialogActions>
           <Button onClick={onClose} color="primary">
@@ -260,7 +261,8 @@ FlightCreateDialog.propTypes = {
     fuelType: PropTypes.shape({
       value: PropTypes.string.isRequired,
       label: PropTypes.string.isRequired
-    })
+    }),
+    oilUplift: PropTypes.number
   }).isRequired,
   organizationMembers: PropTypes.arrayOf(memberShape),
   flightNatures: PropTypes.arrayOf(

--- a/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/__snapshots__/FlightCreateDialog.spec.js.snap
+++ b/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/__snapshots__/FlightCreateDialog.spec.js.snap
@@ -179,6 +179,9 @@ exports[`routes organizations routes aircraft components FlightCreateDialog rend
             </div>
           </div>
         </fieldset>
+        <div class=\\"MuiFormControl-root-73 MuiFormControl-marginNormal-74 MuiFormControl-fullWidth-76\\" data-cy=\\"oilUplift-field\\"><label class=\\"MuiFormLabel-root-84 MuiInputLabel-root-77 MuiInputLabel-formControl-78 MuiInputLabel-animated-81\\" data-shrink=\\"false\\">Öl (L)</label>
+          <div class=\\"MuiInputBase-root-104 MuiInput-root-91 MuiInput-underline-95 MuiInputBase-fullWidth-113 MuiInput-fullWidth-98 MuiInputBase-formControl-105 MuiInput-formControl-92\\"><input aria-invalid=\\"false\\" class=\\"MuiInputBase-input-114 MuiInput-input-99 MuiInputBase-inputType-117 MuiInput-inputType-102\\" type=\\"number\\" step=\\".01\\" value=\\"\\"></div>
+        </div>
       </div>
       <div class=\\"MuiDialogActions-root-264\\"><button tabindex=\\"0\\" class=\\"MuiButtonBase-root-131 MuiButton-root-266 MuiButton-text-268 MuiButton-textPrimary-269 MuiButton-flat-271 MuiButton-flatPrimary-272 MuiDialogActions-action-265\\" type=\\"button\\"><span class=\\"MuiButton-label-267\\"><span>Abbrechen</span></span><span class=\\"MuiTouchRipple-root-143\\"></span></button><button tabindex=\\"0\\" class=\\"MuiButtonBase-root-131 MuiButton-root-266 MuiButton-text-268 MuiButton-textPrimary-269 MuiButton-flat-271 MuiButton-flatPrimary-272 MuiDialogActions-action-265\\" type=\\"submit\\" data-cy=\\"create-button\\"><span class=\\"MuiButton-label-267\\"><span>Speichern</span></span><span class=\\"MuiTouchRipple-root-143\\"></span></button></div>
     </form>

--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -118,7 +118,9 @@ export function* createFlight({
       landings: data.landings,
       fuelUplift: data.fuelUplift / 100,
       fuelUnit: 'litre',
-      fuelType: data.fuelType.value
+      fuelType: data.fuelType.value,
+      oilUplift: data.oilUplift / 100,
+      oilUnit: 'litre'
     }
 
     yield call(

--- a/src/routes/organizations/routes/aircraft/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.spec.js
@@ -95,7 +95,8 @@ describe('routes', () => {
                 },
                 landings: 3,
                 fuelUplift: 5789,
-                fuelType: { value: 'avgas_homebase' }
+                fuelType: { value: 'avgas_homebase' },
+                oilUplift: 245
               }
 
               const action = actions.createFlight(
@@ -171,7 +172,9 @@ describe('routes', () => {
                     landings: 3,
                     fuelUplift: 57.89,
                     fuelUnit: 'litre',
-                    fuelType: 'avgas_homebase'
+                    fuelType: 'avgas_homebase',
+                    oilUplift: 2.45,
+                    oilUnit: 'litre'
                   }
                 )
               )


### PR DESCRIPTION
Only available oil unit is litre (we'll introduce an aircraft
setting at some point)