### PR TITLE
Fix travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,14 +11,15 @@ install:
 jobs:
   include:
     - stage: unit tests
-      script: npm test
+      script:
+        - npm test
+        - npm run codecov
     - stage: integration tests
       script:
         - npm run build
         - npm run cy:test
-    - stage: coverage
-      script: npm run codecov
     - stage: deploy to staging
+      script: npm run build
       deploy:
         provider: firebase
         project: "odch-aircraft-logbook-dev"


### PR DESCRIPTION
- Codecov should run in the same stage as the unit tests itself
  (otherwise it runs in a fresh VM without generated coverage reports)
- As the deployment stages run in a fresh VM, a new build of the
  particular project (dev vs. production) is required