### PR TITLE
Fix bug where only one aerodrome appeared in flight creation dialog

### DIFF
--- a/src/modules/app/sagas.js
+++ b/src/modules/app/sagas.js
@@ -135,7 +135,8 @@ export function* watchAerodromes() {
   const firestore = yield call(getFirestore)
   yield call(firestore.setListener, {
     collection: 'aerodromes',
-    orderBy: 'name'
+    orderBy: 'name',
+    storeAs: 'allAerodromes'
   })
 }
 

--- a/src/modules/app/sagas.spec.js
+++ b/src/modules/app/sagas.spec.js
@@ -502,7 +502,8 @@ describe('modules', () => {
           expect(generator.next(firestore).value).toEqual(
             call(firestore.setListener, {
               collection: 'aerodromes',
-              orderBy: 'name'
+              orderBy: 'name',
+              storeAs: 'allAerodromes'
             })
           )
 

--- a/src/routes/organizations/routes/aircraft/containers/FlightCreateDialogContainer.js
+++ b/src/routes/organizations/routes/aircraft/containers/FlightCreateDialogContainer.js
@@ -37,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
   return {
     organizationMembers: state.firestore.ordered.organizationMembers,
     flightNatures: flightNatures(intl),
-    aerodromes: state.firestore.ordered.aerodromes,
+    aerodromes: state.firestore.ordered.allAerodromes,
     aircraftSettings: aircraftSettings(state, aircraftId),
     data: state.aircraft.createFlightDialog.data,
     validationErrors: state.aircraft.createFlightDialog.validationErrors,


### PR DESCRIPTION
The list of all aerodromes has to be stored with a special name,
as the local collection would be overridden with the result on the
subsequent queries of the aerodromes collection.

New location of the aerodromes in the store (which won't be overridden):
`firestore.ordered.allAerodromes`