### PR TITLE
Use flight counter from last flight instead of from aircraft counters

### DIFF
--- a/src/routes/organizations/routes/aircraft/containers/AircraftDetailContainer.js
+++ b/src/routes/organizations/routes/aircraft/containers/AircraftDetailContainer.js
@@ -4,7 +4,8 @@ import AircraftDetail from '../components/AircraftDetail'
 import {
   getOrganization,
   getAircraft,
-  getAircraftFlights
+  getAircraftFlights,
+  getAircraftFlightsCount
 } from '../../../../../util/getFromState'
 import { fetchAircrafts, fetchMembers } from '../../../module'
 import {
@@ -34,7 +35,7 @@ const mapStateToProps = (state, ownProps) => {
 
   const flightsPagination = aircraft
     ? {
-        rowsCount: aircraft.counters ? aircraft.counters.flights || 0 : 0,
+        rowsCount: getAircraftFlightsCount(state, aircraftId),
         page: state.aircraft.flights.page,
         rowsPerPage: state.aircraft.flights.rowsPerPage
       }

--- a/src/routes/organizations/routes/aircraft/containers/AircraftDetailContainer.spec.js
+++ b/src/routes/organizations/routes/aircraft/containers/AircraftDetailContainer.spec.js
@@ -43,6 +43,9 @@ describe('routes', () => {
                         pilot: {
                           firstname: 'Max',
                           lastname: 'Muster'
+                        },
+                        counters: {
+                          flights: { end: 2 }
                         }
                       },
                       {
@@ -58,6 +61,9 @@ describe('routes', () => {
                         pilot: {
                           firstname: 'Hans',
                           lastname: 'Meier'
+                        },
+                        counters: {
+                          flights: { end: 1 }
                         }
                       }
                     ]
@@ -115,7 +121,8 @@ describe('routes', () => {
                 'match',
                 'organization',
                 'aircraft',
-                'flights'
+                'flights',
+                'flightsPagination'
               ]
 
               expect(Object.keys(component.props)).toEqual(

--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -217,10 +217,9 @@ export function* createFlight({
       dataToStore
     )
 
-    const { page, rowsPerPage } = yield select(aircraftFlightsViewSelector)
-    yield put(
-      actions.fetchFlights(organizationId, aircraftId, page, rowsPerPage)
-    )
+    const { rowsPerPage } = yield select(aircraftFlightsViewSelector)
+    yield put(actions.fetchFlights(organizationId, aircraftId, 0, rowsPerPage))
+    yield put(actions.setFlightsPage(0))
     yield put(actions.createFlightSuccess())
   } catch (e) {
     error(`Failed to create flight`, e)

--- a/src/routes/organizations/routes/aircraft/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.spec.js
@@ -265,12 +265,14 @@ describe('routes', () => {
               )
 
               const aircraftFlightsView = {
-                page: 0,
                 rowsPerPage: 10
               }
 
               expect(generator.next(aircraftFlightsView).value).toEqual(
                 put(actions.fetchFlights(organizationId, aircraftId, 0, 10))
+              )
+              expect(generator.next().value).toEqual(
+                put(actions.setFlightsPage(0))
               )
               expect(generator.next().value).toEqual(
                 put(actions.createFlightSuccess())

--- a/src/util/getFromState.js
+++ b/src/util/getFromState.js
@@ -36,3 +36,14 @@ export const getAircraftFlights = (state, aircraftId, page) => {
   }
   return undefined
 }
+
+export const getAircraftFlightsCount = (state, aircraftId) => {
+  const flights = state.firestore.ordered[`flights-${aircraftId}-0`]
+  if (flights) {
+    if (flights.length > 0) {
+      const newestFlight = flights[0]
+      return newestFlight.counters.flights.end
+    }
+  }
+  return 0
+}

--- a/src/util/getFromState.spec.js
+++ b/src/util/getFromState.spec.js
@@ -1,7 +1,8 @@
 import {
   getOrganization,
   getAircraft,
-  getAircraftFlights
+  getAircraftFlights,
+  getAircraftFlightsCount
 } from './getFromState'
 
 describe('util', () => {
@@ -173,6 +174,68 @@ describe('util', () => {
 
         const flights = getAircraftFlights(state, 'o7flC7jw8jmkOfWo8oyA', 0)
         expect(flights).toEqual([])
+      })
+    })
+
+    describe('getAircraftFlightsCount', () => {
+      it('should return fights end counter of last flight', () => {
+        const state = {
+          firestore: {
+            ordered: {
+              'flights-o7flC7jw8jmkOfWo8oyA-0': [
+                {
+                  counters: {
+                    flights: { end: 4 }
+                  }
+                },
+                {
+                  counters: {
+                    flights: { end: 3 }
+                  }
+                }
+              ],
+              'flights-o7flC7jw8jmkOfWo8oyA-1': [
+                {
+                  counters: {
+                    flights: { end: 2 }
+                  }
+                },
+                {
+                  counters: {
+                    flights: { end: 1 }
+                  }
+                }
+              ]
+            }
+          }
+        }
+
+        const count = getAircraftFlightsCount(state, 'o7flC7jw8jmkOfWo8oyA')
+        expect(count).toEqual(4)
+      })
+
+      it('should return 0 if flights not loaded', () => {
+        const state = {
+          firestore: {
+            ordered: {}
+          }
+        }
+
+        const count = getAircraftFlightsCount(state, 'o7flC7jw8jmkOfWo8oyA')
+        expect(count).toEqual(0)
+      })
+
+      it('should return 0 if it has no flights', () => {
+        const state = {
+          firestore: {
+            ordered: {
+              'flights-o7flC7jw8jmkOfWo8oyA-0': []
+            }
+          }
+        }
+
+        const count = getAircraftFlightsCount(state, 'o7flC7jw8jmkOfWo8oyA')
+        expect(count).toEqual(0)
       })
     })
   })


### PR DESCRIPTION
- aircraft counters are updated by a trigger and, thus, they're
  a bit delayed -> counter from the last flight is up to date
- also go to first page after a flight is created, as the created
  flight will be the newest one (user can't create a flight somewhere
  in between)