### PR TITLE
Restrict access on Firestore documents to authenticated users

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -1,7 +1,7 @@
 service cloud.firestore {
   match /databases/{database}/documents {
     match /{document=**} {
-      allow read, write;
+      allow read, write: if request.auth.uid != null;
     }
   }
 }


### PR DESCRIPTION
More fine-granular rules will be defined once all the queries are
more stable. The queries have to reflect the defined security rules
at all times (otherwise the query execution fails) which can get quite
cumbersome during this stage of development where the queries still
are changing.