### PR TITLE
Add missing dependency for Cypress on Travis after Ubuntu update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 language: node_js
 node_js:
   - "10"
+addons:
+  apt:
+    packages:
+      - libgconf-2-4
 cache:
   directories:
     - ~/.npm


### PR DESCRIPTION
Fixes the following error:
error while loading shared libraries: libgconf-2.so.4:
cannot open shared object file: No such file or directory