### PR TITLE
Move start and end date for export flights form to redux state

### DIFF
--- a/src/routes/organizations/routes/settings/components/ExportFlightsForm/ExportFlightsForm.js
+++ b/src/routes/organizations/routes/settings/components/ExportFlightsForm/ExportFlightsForm.js
@@ -4,7 +4,6 @@ import { injectIntl, FormattedMessage } from 'react-intl'
 import Button from '@material-ui/core/Button'
 import { KeyboardDatePicker } from '@material-ui/pickers'
 import { withStyles } from '@material-ui/core/styles'
-import moment from 'moment-timezone'
 import { intl as intlShape } from '../../../../../../shapes'
 
 const styles = {
@@ -14,31 +13,19 @@ const styles = {
 }
 
 class ExportFlightsForm extends React.Component {
-  state = {
-    startDate: moment()
-      .subtract(1, 'months')
-      .startOf('month')
-      .format('YYYY-MM-DD'),
-    endDate: moment()
-      .subtract(1, 'months')
-      .endOf('month')
-      .format('YYYY-MM-DD')
-  }
-
   handleSubmit = e => {
-    const { exportFlights, organizationId } = this.props
-    const { startDate, endDate } = this.state
+    const { exportFlights, organizationId, data } = this.props
 
     e.preventDefault()
 
-    if (startDate && endDate) {
-      exportFlights(organizationId, startDate, endDate)
+    if (data.startDate && data.endDate) {
+      exportFlights(organizationId, data.startDate, data.endDate)
     }
   }
 
   handleDateChange = name => momentDate => {
     const newValue = momentDate ? momentDate.format('YYYY-MM-DD') : null
-    this.setState({
+    this.props.updateData({
       [name]: newValue
     })
   }
@@ -59,8 +46,8 @@ class ExportFlightsForm extends React.Component {
             color="primary"
             onClick={this.handleFlightsExportClick}
             disabled={
-              !this.state.startDate ||
-              !this.state.endDate ||
+              !this.props.data.startDate ||
+              !this.props.data.endDate ||
               this.props.submitting
             }
           >
@@ -76,7 +63,7 @@ class ExportFlightsForm extends React.Component {
       label={this.msg(
         `organization.settings.exportflights.${name.toLowerCase()}`
       )}
-      value={this.state[name]}
+      value={this.props.data[name]}
       onChange={this.handleDateChange(name)}
       className={this.props.classes.datePicker}
       disabled={this.props.submitting}
@@ -90,6 +77,11 @@ class ExportFlightsForm extends React.Component {
 ExportFlightsForm.propTypes = {
   organizationId: PropTypes.string.isRequired,
   submitting: PropTypes.bool.isRequired,
+  data: PropTypes.shape({
+    startDate: PropTypes.string,
+    endDate: PropTypes.string
+  }),
+  updateData: PropTypes.func.isRequired,
   exportFlights: PropTypes.func.isRequired,
   intl: intlShape,
   classes: PropTypes.object.isRequired

--- a/src/routes/organizations/routes/settings/components/OrganizationSettings/OrganizationSettings.spec.js
+++ b/src/routes/organizations/routes/settings/components/OrganizationSettings/OrganizationSettings.spec.js
@@ -77,7 +77,11 @@ describe('routes', () => {
                     open: false
                   },
                   exportFlightsForm: {
-                    submitting: false
+                    submitting: false,
+                    data: {
+                      startDate: '2019-08-01',
+                      endDate: '2019-08-31'
+                    }
                   }
                 }
               })

--- a/src/routes/organizations/routes/settings/components/OrganizationSettingsPage/OrganizationSettingsPage.spec.js
+++ b/src/routes/organizations/routes/settings/components/OrganizationSettingsPage/OrganizationSettingsPage.spec.js
@@ -51,7 +51,11 @@ describe('routes', () => {
                     open: false
                   },
                   exportFlightsForm: {
-                    submitting: false
+                    submitting: false,
+                    data: {
+                      startDate: '2019-08-01',
+                      endDate: '2019-08-31'
+                    }
                   },
                   members: {
                     page: 0

--- a/src/routes/organizations/routes/settings/containers/ExportFlightsFormContainer.js
+++ b/src/routes/organizations/routes/settings/containers/ExportFlightsFormContainer.js
@@ -1,18 +1,20 @@
 import { compose } from 'redux'
 import { connect } from 'react-redux'
-import { exportFlights } from '../module'
+import { exportFlights, updateExportFlightsFormData } from '../module'
 import ExportFlightsForm from '../components/ExportFlightsForm'
 import { getOrganization } from '../../../../../util/getFromState'
 
 const mapStateToProps = (state, ownProps) => {
   return {
     organization: getOrganization(state, ownProps.organizationId),
-    submitting: state.organizationSettings.exportFlightsForm.submitting
+    submitting: state.organizationSettings.exportFlightsForm.submitting,
+    data: state.organizationSettings.exportFlightsForm.data
   }
 }
 
 const mapActionCreators = {
-  exportFlights
+  exportFlights,
+  updateData: updateExportFlightsFormData
 }
 
 export default compose(

--- a/src/routes/organizations/routes/settings/module/actions.js
+++ b/src/routes/organizations/routes/settings/module/actions.js
@@ -20,6 +20,8 @@ export const SET_MEMBERS_PAGE = 'organizationSettings/SET_MEMBERS_PAGE'
 export const EXPORT_FLIGHTS = 'organizationSettings/EXPORT_FLIGHTS'
 export const SET_EXPORT_FLIGHTS_FORM_SUBMITTING =
   'organizationSettings/SET_EXPORT_FLIGHTS_FORM_SUBMITTING'
+export const UPDATE_EXPORT_FLIGHTS_FORM_DATA =
+  'organizationSettings/UPDATE_EXPORT_FLIGHTS_FORM_DATA'
 
 export const openCreateMemberDialog = () => ({
   type: OPEN_CREATE_MEMBER_DIALOG
@@ -95,5 +97,12 @@ export const setExportFlightsDialogSubmitting = submitting => ({
   type: SET_EXPORT_FLIGHTS_FORM_SUBMITTING,
   payload: {
     submitting
+  }
+})
+
+export const updateExportFlightsFormData = data => ({
+  type: UPDATE_EXPORT_FLIGHTS_FORM_DATA,
+  payload: {
+    data
   }
 })

--- a/src/routes/organizations/routes/settings/module/index.js
+++ b/src/routes/organizations/routes/settings/module/index.js
@@ -1,6 +1,7 @@
 import {
   openCreateMemberDialog,
   exportFlights,
+  updateExportFlightsFormData,
   closeCreateMemberDialog,
   updateCreateMemberDialogData,
   createMember,
@@ -15,6 +16,7 @@ import sagas from './sagas'
 export {
   openCreateMemberDialog,
   exportFlights,
+  updateExportFlightsFormData,
   closeCreateMemberDialog,
   updateCreateMemberDialogData,
   createMember,

--- a/src/routes/organizations/routes/settings/module/reducer.js
+++ b/src/routes/organizations/routes/settings/module/reducer.js
@@ -1,4 +1,5 @@
 import _set from 'lodash.set'
+import moment from 'moment-timezone'
 import { createReducer } from '../../../../../util/reducer'
 import * as actions from './actions'
 
@@ -17,7 +18,17 @@ export const INITIAL_STATE = {
     submitting: false
   },
   exportFlightsForm: {
-    submitting: false
+    submitting: false,
+    data: {
+      startDate: moment()
+        .subtract(1, 'months')
+        .startOf('month')
+        .format('YYYY-MM-DD'),
+      endDate: moment()
+        .subtract(1, 'months')
+        .endOf('month')
+        .format('YYYY-MM-DD')
+    }
   },
   members: {
     page: 0
@@ -108,9 +119,29 @@ const setMembersPage = (state, action) => ({
 const setExportFlightsFormSubmitting = (state, action) => ({
   ...state,
   exportFlightsForm: {
+    ...state.exportFlightsForm,
     submitting: action.payload.submitting
   }
 })
+
+const updateExportFlightsFormData = (state, action) => {
+  const newData = {
+    ...state.exportFlightsForm.data
+  }
+
+  Object.keys(action.payload.data).forEach(key => {
+    const value = action.payload.data[key]
+    _set(newData, key, value)
+  })
+
+  return {
+    ...state,
+    exportFlightsForm: {
+      ...state.exportFlightsForm,
+      data: newData
+    }
+  }
+}
 
 const ACTION_HANDLERS = {
   [actions.OPEN_CREATE_MEMBER_DIALOG]: openCreateMemberDialog,
@@ -123,7 +154,8 @@ const ACTION_HANDLERS = {
   [actions.CLOSE_DELETE_MEMBER_DIALOG]: closeDeleteMemberDialog,
   [actions.DELETE_MEMBER]: setDeleteMemberDialogSubmitting,
   [actions.SET_MEMBERS_PAGE]: setMembersPage,
-  [actions.SET_EXPORT_FLIGHTS_FORM_SUBMITTING]: setExportFlightsFormSubmitting
+  [actions.SET_EXPORT_FLIGHTS_FORM_SUBMITTING]: setExportFlightsFormSubmitting,
+  [actions.UPDATE_EXPORT_FLIGHTS_FORM_DATA]: updateExportFlightsFormData
 }
 
 export default createReducer(INITIAL_STATE, ACTION_HANDLERS)

--- a/src/routes/organizations/routes/settings/module/reducer.spec.js
+++ b/src/routes/organizations/routes/settings/module/reducer.spec.js
@@ -1,3 +1,4 @@
+import moment from 'moment-timezone'
 import * as actions from './actions'
 import reducer from './reducer'
 
@@ -16,7 +17,17 @@ export const INITIAL_STATE = {
     submitting: false
   },
   exportFlightsForm: {
-    submitting: false
+    submitting: false,
+    data: {
+      startDate: moment()
+        .subtract(1, 'months')
+        .startOf('month')
+        .format('YYYY-MM-DD'),
+      endDate: moment()
+        .subtract(1, 'months')
+        .endOf('month')
+        .format('YYYY-MM-DD')
+    }
   },
   members: {
     page: 0
@@ -238,14 +249,49 @@ describe('routes', () => {
               reducer(
                 {
                   exportFlightsForm: {
-                    submitting: false
+                    submitting: false,
+                    data: {
+                      startDate: '2019-08-01',
+                      endDate: '2019-08-31'
+                    }
                   }
                 },
                 actions.setExportFlightsDialogSubmitting(true)
               )
             ).toEqual({
               exportFlightsForm: {
-                submitting: true
+                submitting: true,
+                data: {
+                  startDate: '2019-08-01',
+                  endDate: '2019-08-31'
+                }
+              }
+            })
+          })
+
+          it('handles UPDATE_EXPORT_FLIGHTS_FORM_DATA action', () => {
+            expect(
+              reducer(
+                {
+                  exportFlightsForm: {
+                    submitting: false,
+                    data: {
+                      startDate: '2019-08-01',
+                      endDate: '2019-08-31'
+                    }
+                  }
+                },
+                actions.updateExportFlightsFormData({
+                  startDate: '2019-07-01'
+                })
+              )
+            ).toEqual({
+              exportFlightsForm: {
+                submitting: false,
+                data: {
+                  startDate: '2019-07-01',
+                  endDate: '2019-08-31'
+                }
               }
             })
           })


### PR DESCRIPTION
Makes it easier to test. We cannot hardcode the date values for the
components for the Jest snapshot tests if the date values are hardcoded
in the form state within the React component.