### PR TITLE
Also store member and aerodrome data in flight (not just a reference)

### DIFF
--- a/src/modules/app/sagas.js
+++ b/src/modules/app/sagas.js
@@ -82,8 +82,13 @@ export const collectReferences = (data, referenceItems) => {
 }
 
 export function* resolveReference(id, ref) {
-  const doc = yield call(ref.get.bind(ref))
-  const data = doc.data()
+  let data = ref
+
+  if (ref && typeof ref.get === 'function') {
+    const doc = yield call(ref.get.bind(ref))
+    data = doc.data()
+  }
+
   return {
     id,
     data

--- a/src/modules/app/sagas.spec.js
+++ b/src/modules/app/sagas.spec.js
@@ -287,6 +287,24 @@ describe('modules', () => {
 
           expect(generator.next().done).toEqual(true)
         })
+
+        it('should return data right away if not a reference', () => {
+          const data = { name: 'Lommis' }
+
+          const id = {
+            key: 'vuB0UPVhvhl8ikOgJjvC',
+            item: 'departureAerodrome'
+          }
+
+          const generator = sagas.resolveReference(id, data)
+
+          expect(generator.next().value).toEqual({
+            id,
+            data: { name: 'Lommis' }
+          })
+
+          expect(generator.next().done).toEqual(true)
+        })
       })
 
       describe('populate', () => {

--- a/src/routes/organizations/routes/aircraft/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.spec.js
@@ -11,6 +11,8 @@ import { fetchAerodromes } from '../../../module'
 
 const counter = (start, end) => ({ start, end })
 
+const getFromMap = map => name => map[name]
+
 describe('routes', () => {
   describe('organizations', () => {
     describe('routes', () => {
@@ -66,7 +68,8 @@ describe('routes', () => {
                     populate: [
                       'departureAerodrome',
                       'destinationAerodrome',
-                      'pilot'
+                      'pilot',
+                      'instructor'
                     ]
                   },
                   {}
@@ -188,17 +191,36 @@ describe('routes', () => {
                 id: 'member-id'
               }
               const owner = { ref: 'owner-ref' }
-              const pilot = { ref: 'pilot-ref' }
-              const instructor = { ref: 'instructor-ref' }
+              const pilot = {
+                exists: true,
+                ref: 'pilot-ref',
+                get: getFromMap({
+                  firstname: 'Max',
+                  lastname: 'Superpilot',
+                  nr: '9999'
+                })
+              }
+              const instructor = {
+                exists: true,
+                ref: 'instructor-ref',
+                get: getFromMap({
+                  firstname: 'Hans',
+                  lastname: 'Superfluglehrer'
+                })
+              }
               const departureAerodrome = {
                 ref: 'dep-ad-ref',
-                data: () => ({
+                get: getFromMap({
+                  identification: 'LSZT',
+                  name: 'Lommis',
                   timezone: 'Europe/Zurich'
                 })
               }
               const destinationAerodrome = {
                 ref: 'dest-ad-ref',
-                data: () => ({
+                get: getFromMap({
+                  identification: 'LSPV',
+                  name: 'Wangen-Lachen',
                   timezone: 'Europe/Zurich'
                 })
               }
@@ -240,11 +262,31 @@ describe('routes', () => {
                   {
                     deleted: false,
                     owner: 'owner-ref',
-                    pilot: 'pilot-ref',
-                    instructor: 'instructor-ref',
+                    pilot: {
+                      firstname: 'Max',
+                      lastname: 'Superpilot',
+                      nr: '9999',
+                      member: 'pilot-ref'
+                    },
+                    instructor: {
+                      firstname: 'Hans',
+                      lastname: 'Superfluglehrer',
+                      nr: null,
+                      member: 'instructor-ref'
+                    },
                     nature: 'vp',
-                    departureAerodrome: 'dep-ad-ref',
-                    destinationAerodrome: 'dest-ad-ref',
+                    departureAerodrome: {
+                      aerodrome: 'dep-ad-ref',
+                      identification: 'LSZT',
+                      name: 'Lommis',
+                      timezone: 'Europe/Zurich'
+                    },
+                    destinationAerodrome: {
+                      aerodrome: 'dest-ad-ref',
+                      identification: 'LSPV',
+                      name: 'Wangen-Lachen',
+                      timezone: 'Europe/Zurich'
+                    },
                     blockOffTime: new Date('2018-12-15T09:00:00.000Z'),
                     takeOffTime: new Date('2018-12-15T09:05:00.000Z'),
                     landingTime: new Date('2018-12-15T09:35:00.000Z'),


### PR DESCRIPTION
- Old flights won't be migrated. When flights are fetched, member
  and aerodrome references are still populated in old records (can
  be skipped in new records and data can be returned as it is).
- Also fixed a bug where the instructor reference wasn't fetched.