### PR TITLE
Fix getting destination aerodrome of last flight when creating new one

### DIFF
--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -121,10 +121,13 @@ export function* getFlight(organizationId, aircraftId, flightId) {
 
 export async function getDestinationAerodrome(flight) {
   if (flight.destinationAerodrome) {
-    const document = await flight.destinationAerodrome.get()
-    const data = document.data()
-    data.id = flight.destinationAerodrome.id
-    return data
+    if (typeof flight.destinationAerodrome.get === 'function') {
+      const document = await flight.destinationAerodrome.get()
+      const data = document.data()
+      data.id = flight.destinationAerodrome.id
+      return data
+    }
+    return flight.destinationAerodrome
   }
   return null
 }
@@ -139,7 +142,8 @@ export const aerodromeObject = aeodromeDocument => ({
   name: aeodromeDocument.get('name') || null,
   identification: aeodromeDocument.get('identification') || null,
   timezone: aeodromeDocument.get('timezone') || null,
-  aerodrome: aeodromeDocument.ref
+  aerodrome: aeodromeDocument.ref,
+  id: aeodromeDocument.id
 })
 
 export const memberObject = memberDocument =>
@@ -148,7 +152,8 @@ export const memberObject = memberDocument =>
         firstname: memberDocument.get('firstname') || null,
         lastname: memberDocument.get('lastname') || null,
         nr: memberDocument.get('nr') || null,
-        member: memberDocument.ref
+        member: memberDocument.ref,
+        id: memberDocument.id
       }
     : null
 

--- a/src/routes/organizations/routes/aircraft/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.spec.js
@@ -194,6 +194,7 @@ describe('routes', () => {
               const pilot = {
                 exists: true,
                 ref: 'pilot-ref',
+                id: 'pilot-id',
                 get: getFromMap({
                   firstname: 'Max',
                   lastname: 'Superpilot',
@@ -203,6 +204,7 @@ describe('routes', () => {
               const instructor = {
                 exists: true,
                 ref: 'instructor-ref',
+                id: 'instructor-id',
                 get: getFromMap({
                   firstname: 'Hans',
                   lastname: 'Superfluglehrer'
@@ -210,6 +212,7 @@ describe('routes', () => {
               }
               const departureAerodrome = {
                 ref: 'dep-ad-ref',
+                id: 'dep-ad-id',
                 get: getFromMap({
                   identification: 'LSZT',
                   name: 'Lommis',
@@ -218,6 +221,7 @@ describe('routes', () => {
               }
               const destinationAerodrome = {
                 ref: 'dest-ad-ref',
+                id: 'dest-ad-id',
                 get: getFromMap({
                   identification: 'LSPV',
                   name: 'Wangen-Lachen',
@@ -266,23 +270,27 @@ describe('routes', () => {
                       firstname: 'Max',
                       lastname: 'Superpilot',
                       nr: '9999',
-                      member: 'pilot-ref'
+                      member: 'pilot-ref',
+                      id: 'pilot-id'
                     },
                     instructor: {
                       firstname: 'Hans',
                       lastname: 'Superfluglehrer',
                       nr: null,
-                      member: 'instructor-ref'
+                      member: 'instructor-ref',
+                      id: 'instructor-id'
                     },
                     nature: 'vp',
                     departureAerodrome: {
                       aerodrome: 'dep-ad-ref',
+                      id: 'dep-ad-id',
                       identification: 'LSZT',
                       name: 'Lommis',
                       timezone: 'Europe/Zurich'
                     },
                     destinationAerodrome: {
                       aerodrome: 'dest-ad-ref',
+                      id: 'dest-ad-id',
                       identification: 'LSPV',
                       name: 'Wangen-Lachen',
                       timezone: 'Europe/Zurich'


### PR DESCRIPTION
`getDestinationAerodrome` still assumed that `flight.destinationAerodrome`
is an instance of `DocumentReference` and that the actual data has to be
resolved using the `get` function.
However, newer flights don't just have a reference to the aerodrome,
but also have the actual data of the aerodrome stored in the
`destinationAerodrome` property. So in this case, we don't have to
resolve a reference but can return the data right away.