### PR TITLE
Add individual invitation page for organization members

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -3,5 +3,8 @@ service cloud.firestore {
     match /{document=**} {
       allow read, write: if request.auth.uid != null;
     }
+    match /organizations/{organization}/members/{member} {
+      allow read;
+    }
   }
 }

--- a/functions/organization/userorganizations.function.js
+++ b/functions/organization/userorganizations.function.js
@@ -19,17 +19,23 @@ const updateUserOrganizations = (change, fieldName, organizationRef) => {
 
   if (previousData && previousData[fieldName]) {
     promises.push(
-      previousData[fieldName].update({
-        organizations: admin.firestore.FieldValue.arrayRemove(organizationRef)
-      })
+      previousData[fieldName].set(
+        {
+          organizations: admin.firestore.FieldValue.arrayRemove(organizationRef)
+        },
+        { merge: true }
+      )
     )
   }
 
   if (data && data[fieldName]) {
     promises.push(
-      data[fieldName].update({
-        organizations: admin.firestore.FieldValue.arrayUnion(organizationRef)
-      })
+      data[fieldName].set(
+        {
+          organizations: admin.firestore.FieldValue.arrayUnion(organizationRef)
+        },
+        { merge: true }
+      )
     )
   }
 

--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -3,8 +3,20 @@ import PropTypes from 'prop-types'
 import LoadingIcon from './LoadingIcon'
 
 class App extends React.Component {
+  loadAerodromes = () => {
+    const { auth, watchAerodromes } = this.props
+
+    if (auth.isLoaded && !auth.isEmpty) {
+      watchAerodromes()
+    }
+  }
+
   componentDidMount() {
-    this.props.watchAerodromes()
+    this.loadAerodromes()
+  }
+
+  componentDidUpdate() {
+    this.loadAerodromes()
   }
 
   render() {
@@ -19,7 +31,7 @@ App.propTypes = {
   auth: PropTypes.shape({
     isLoaded: PropTypes.bool.isRequired,
     isEmpty: PropTypes.bool.isRequired
-  }),
+  }).isRequired,
   children: PropTypes.element,
   watchAerodromes: PropTypes.func.isRequired
 }

--- a/src/components/App/App.spec.js
+++ b/src/components/App/App.spec.js
@@ -46,11 +46,7 @@ describe('components', () => {
       expect(tree).toMatchSnapshot()
     })
 
-    it('calls watchAerodromes when mounted', () => {
-      const auth = {
-        isLoaded: false,
-        isEmpty: true
-      }
+    const testWatchAerodromes = (auth, expectCall) => {
       const store = configureStore()({
         firebase: {
           auth
@@ -61,11 +57,41 @@ describe('components', () => {
 
       renderIntl(
         <Provider store={store}>
-          <App auth={auth} watchAerodromes={watchAerodromes} />
+          <App auth={auth} watchAerodromes={watchAerodromes}>
+            <div>content</div>
+          </App>
         </Provider>
       )
 
-      expect(watchAerodromes).toBeCalled()
+      if (expectCall) {
+        expect(watchAerodromes).toBeCalled()
+      } else {
+        expect(watchAerodromes).not.toBeCalled()
+      }
+    }
+
+    it('calls watchAerodromes when mounted and logged in', () => {
+      const auth = {
+        isLoaded: true,
+        isEmpty: false
+      }
+      testWatchAerodromes(auth, true)
+    })
+
+    it('does not watchAerodromes when mounted and auth loaded but empty', () => {
+      const auth = {
+        isLoaded: true,
+        isEmpty: true
+      }
+      testWatchAerodromes(auth, false)
+    })
+
+    it('does not watchAerodromes when auth not loaded', () => {
+      const auth = {
+        isLoaded: false,
+        isEmpty: true
+      }
+      testWatchAerodromes(auth, false)
     })
   })
 })

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -168,6 +168,13 @@
   "organization.aerodrome.create.dialog.buttons.cancel": "Abbrechen",
   "organization.aerodrome.create.dialog.buttons.create": "Flugplatz erstellen",
 
+  "organization.invite.greeting": "Hallo {firstname}!",
+  "organization.invite.text": "Du wurdest eingeladen, der Organisation {organization} beizutreten.",
+  "organization.invite.login": "Melde dich an, um fortzufahren.",
+  "organization.invite.accept": "Mit Konto {account} beitreten",
+  "organization.invite.change_account": "Mit anderem Konto beitreten",
+  "organization.invite.invalid": "Die angeforderte Einladung wurde nicht gefunden oder ist nicht mehr gültig.",
+
   "aircraft.settings.fueltypes": "Treibstofftypen",
   "aircraft.settings.fueltypes.none": "Keine Treibstofftypen erfasst"
 }

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -2,6 +2,7 @@ import start from './start'
 import organizations from './organizations'
 import detail from './organizations/routes/detail'
 import settings from './organizations/routes/settings'
+import invite from './organizations/routes/invite'
 import aircraft from './organizations/routes/aircraft'
 import aircraftSettings from './organizations/routes/aircraft/routes/settings'
 import login from './login'
@@ -31,6 +32,12 @@ export const createRoutes = store => [
     exact: true,
     render: settings(store),
     protected: true
+  },
+  {
+    path: '/organizations/:organizationId/invite/:inviteId',
+    exact: true,
+    render: invite(store),
+    protected: false
   },
   {
     path: '/organizations/:organizationId/aircrafts/:aircraftId',

--- a/src/routes/organizations/routes/invite/components/Invitation/Invitation.js
+++ b/src/routes/organizations/routes/invite/components/Invitation/Invitation.js
@@ -1,0 +1,149 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withStyles from '@material-ui/core/styles/withStyles'
+import Typography from '@material-ui/core/Typography'
+import Button from '@material-ui/core/Button'
+import CircularProgress from '@material-ui/core/CircularProgress'
+import { Redirect } from 'react-router-dom'
+import isLoaded from '../../../../../../util/isLoaded'
+import LoadingIcon from '../../../../../../components/LoadingIcon'
+import GoogleLogin from '../../../../../login/containers/GoogleLoginContainer'
+import { FormattedMessage } from 'react-intl'
+
+const styles = (/*theme*/) => ({
+  container: {
+    textAlign: 'center',
+    position: 'relative'
+  },
+  acceptButton: {
+    marginTop: '1em',
+    marginBottom: '1em'
+  },
+  loginContainer: {
+    marginTop: '2em'
+  },
+  loginText: {
+    marginBottom: '1em'
+  }
+})
+
+class Invitation extends React.Component {
+  componentDidMount() {
+    const { invite, organizationId, inviteId, fetchInvite } = this.props
+
+    if (!isLoaded(invite)) {
+      fetchInvite(organizationId, inviteId)
+    }
+  }
+
+  handleAccept = () => {
+    const { organizationId, inviteId, acceptInvite } = this.props
+    acceptInvite(organizationId, inviteId)
+  }
+
+  render() {
+    const {
+      organizationId,
+      invite,
+      auth,
+      acceptInProgress,
+      logout,
+      classes
+    } = this.props
+
+    if (!isLoaded(invite)) {
+      return (
+        <div className={classes.container}>
+          <LoadingIcon />
+        </div>
+      )
+    }
+
+    if (invite === null) {
+      return (
+        <div className={classes.container}>
+          <Typography>
+            <FormattedMessage id="organization.invite.invalid" />
+          </Typography>
+        </div>
+      )
+    }
+
+    if (invite.accepted === true) {
+      return <Redirect to={`/organizations/${organizationId}`} />
+    }
+
+    return (
+      <div className={classes.container}>
+        <Typography variant="h4" gutterBottom>
+          <FormattedMessage
+            id="organization.invite.greeting"
+            values={{ firstname: invite.firstname }}
+          />
+        </Typography>
+        <Typography gutterBottom>
+          <FormattedMessage
+            id="organization.invite.text"
+            values={{ organization: <strong>{organizationId}</strong> }}
+          />
+        </Typography>
+        {auth.isEmpty && (
+          <div className={classes.loginContainer}>
+            <Typography className={classes.loginText}>
+              <FormattedMessage id="organization.invite.login" />
+            </Typography>
+            <GoogleLogin />
+          </div>
+        )}
+        {!auth.isEmpty && (
+          <React.Fragment>
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={this.handleAccept}
+              className={classes.acceptButton}
+              disabled={acceptInProgress}
+              fullWidth
+            >
+              {acceptInProgress && (
+                <CircularProgress
+                  size={16}
+                  className={classes.loadingIndicator}
+                />
+              )}
+              <FormattedMessage
+                id="organization.invite.accept"
+                values={{ account: auth.email }}
+              />
+            </Button>
+            <Button onClick={logout} disabled={acceptInProgress} fullWidth>
+              <FormattedMessage id="organization.invite.change_account" />
+            </Button>
+          </React.Fragment>
+        )}
+      </div>
+    )
+  }
+}
+
+Invitation.propTypes = {
+  auth: PropTypes.shape({
+    isLoaded: PropTypes.bool.isRequired,
+    isEmpty: PropTypes.bool.isRequired,
+    email: PropTypes.string
+  }).isRequired,
+  organizationId: PropTypes.string.isRequired,
+  inviteId: PropTypes.string.isRequired,
+  invite: PropTypes.shape({
+    firstname: PropTypes.string.isRequired,
+    lastname: PropTypes.string.isRequired,
+    accepted: PropTypes.bool.isRequired
+  }),
+  acceptInProgress: PropTypes.bool.isRequired,
+  classes: PropTypes.object.isRequired,
+  fetchInvite: PropTypes.func.isRequired,
+  acceptInvite: PropTypes.func.isRequired,
+  logout: PropTypes.func.isRequired
+}
+
+export default withStyles(styles)(Invitation)

--- a/src/routes/organizations/routes/invite/components/Invitation/index.js
+++ b/src/routes/organizations/routes/invite/components/Invitation/index.js
@@ -1,0 +1,3 @@
+import Invitation from './Invitation'
+
+export default Invitation

--- a/src/routes/organizations/routes/invite/components/InvitePage/InvitePage.js
+++ b/src/routes/organizations/routes/invite/components/InvitePage/InvitePage.js
@@ -1,0 +1,36 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import withStyles from '@material-ui/core/styles/withStyles'
+import Invitation from '../../containers/InvitationContainer'
+
+const styles = theme => ({
+  layout: {
+    width: 'auto',
+    display: 'block',
+    marginTop: theme.spacing(8),
+    marginLeft: theme.spacing(3),
+    marginRight: theme.spacing(3),
+    [theme.breakpoints.up(500 + theme.spacing(3 * 2))]: {
+      width: 500,
+      marginLeft: 'auto',
+      marginRight: 'auto'
+    }
+  }
+})
+
+const InvitePage = ({ router: { match }, classes }) => (
+  <main className={classes.layout}>
+    <Invitation match={match} />
+  </main>
+)
+
+InvitePage.propTypes = {
+  router: PropTypes.shape({
+    match: PropTypes.shape({
+      params: PropTypes.object.isRequired
+    }).isRequired
+  }),
+  classes: PropTypes.object.isRequired
+}
+
+export default withStyles(styles)(InvitePage)

--- a/src/routes/organizations/routes/invite/components/InvitePage/index.js
+++ b/src/routes/organizations/routes/invite/components/InvitePage/index.js
@@ -1,0 +1,3 @@
+import InvitePage from './InvitePage'
+
+export default InvitePage

--- a/src/routes/organizations/routes/invite/containers/InvitationContainer.js
+++ b/src/routes/organizations/routes/invite/containers/InvitationContainer.js
@@ -1,0 +1,65 @@
+import { compose } from 'redux'
+import { connect } from 'react-redux'
+import Invitation from '../components/Invitation'
+import { fetchInvite, acceptInvite } from '../module'
+import { logout } from '../../../../../modules/app'
+
+export const getInvite = state => {
+  const invite = state.invite.invite
+
+  if (!invite) {
+    return invite
+  }
+
+  if (invite.deleted === true) {
+    return null
+  }
+
+  let accepted = false
+
+  if (invite.user) {
+    const auth = state.firebase.auth
+    if (auth.isEmpty === false) {
+      if (auth.uid === invite.user.id) {
+        accepted = true
+      } else {
+        return null
+      }
+    }
+  }
+
+  return {
+    firstname: invite.firstname,
+    lastname: invite.lastname,
+    accepted
+  }
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const {
+    match: {
+      params: { organizationId, inviteId }
+    }
+  } = ownProps
+
+  return {
+    organizationId: organizationId,
+    inviteId: inviteId,
+    auth: state.firebase.auth,
+    invite: getInvite(state),
+    acceptInProgress: state.invite.acceptInProgress
+  }
+}
+
+const mapActionCreators = {
+  fetchInvite,
+  acceptInvite,
+  logout
+}
+
+export default compose(
+  connect(
+    mapStateToProps,
+    mapActionCreators
+  )
+)(Invitation)

--- a/src/routes/organizations/routes/invite/containers/InvitationContainer.spec.js
+++ b/src/routes/organizations/routes/invite/containers/InvitationContainer.spec.js
@@ -1,0 +1,103 @@
+import { getInvite } from './InvitationContainer'
+
+describe('routes', () => {
+  describe('organizations', () => {
+    describe('routes', () => {
+      describe('invite', () => {
+        describe('containers', () => {
+          describe('InvitationContainer', () => {
+            describe('getInvite', () => {
+              it('should return undefined if invite not loaded', () => {
+                const state = {
+                  invite: {}
+                }
+                expect(getInvite(state)).toEqual(undefined)
+              })
+
+              it('should return null if invite is null', () => {
+                const state = {
+                  invite: {
+                    invite: null
+                  }
+                }
+                expect(getInvite(state)).toEqual(null)
+              })
+
+              it('should return null if invite is deleted', () => {
+                const state = {
+                  invite: {
+                    invite: {
+                      deleted: true
+                    }
+                  }
+                }
+                expect(getInvite(state)).toEqual(null)
+              })
+
+              it('should return invite if not accepted', () => {
+                const state = {
+                  invite: {
+                    invite: {
+                      firstname: 'Max',
+                      lastname: 'Muster',
+                      deleted: false
+                    }
+                  }
+                }
+                expect(getInvite(state)).toEqual({
+                  firstname: 'Max',
+                  lastname: 'Muster',
+                  accepted: false
+                })
+              })
+
+              it('should return accepted invite if linked user is current user', () => {
+                const state = {
+                  invite: {
+                    invite: {
+                      firstname: 'Max',
+                      lastname: 'Muster',
+                      deleted: false,
+                      user: { id: 'user-id' }
+                    }
+                  },
+                  firebase: {
+                    auth: {
+                      isEmpty: false,
+                      uid: 'user-id'
+                    }
+                  }
+                }
+                expect(getInvite(state)).toEqual({
+                  firstname: 'Max',
+                  lastname: 'Muster',
+                  accepted: true
+                })
+              })
+
+              it('should return null if linked user is not current user', () => {
+                const state = {
+                  invite: {
+                    invite: {
+                      firstname: 'Max',
+                      lastname: 'Muster',
+                      deleted: false,
+                      user: { id: 'other-user-id' }
+                    }
+                  },
+                  firebase: {
+                    auth: {
+                      isEmpty: false,
+                      uid: 'user-id'
+                    }
+                  }
+                }
+                expect(getInvite(state)).toEqual(null)
+              })
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/routes/organizations/routes/invite/index.js
+++ b/src/routes/organizations/routes/invite/index.js
@@ -1,0 +1,4 @@
+import { loadRoute } from '../../../../util/route'
+
+export default (store, input) =>
+  loadRoute('organizationInvite', store, input, () => import('./route'))

--- a/src/routes/organizations/routes/invite/module/actions.js
+++ b/src/routes/organizations/routes/invite/module/actions.js
@@ -1,0 +1,32 @@
+export const FETCH_INVITE = 'organizationInvite/FETCH_INVITE'
+export const SET_INVITE = 'organizationInvite/SET_INVITE'
+export const ACCEPT_INVITE = 'organizationInvite/ACCEPT_INVITE'
+export const SET_ACCEPT_IN_PROGRESS =
+  'organizationInvite/SET_ACCEPT_IN_PROGRESS'
+
+export const fetchInvite = (organizationId, inviteId) => ({
+  type: FETCH_INVITE,
+  payload: {
+    organizationId,
+    inviteId
+  }
+})
+
+export const setInvite = invite => ({
+  type: SET_INVITE,
+  payload: {
+    invite
+  }
+})
+
+export const acceptInvite = (organizationId, inviteId) => ({
+  type: ACCEPT_INVITE,
+  payload: {
+    organizationId,
+    inviteId
+  }
+})
+
+export const setAcceptInProgress = () => ({
+  type: SET_ACCEPT_IN_PROGRESS
+})

--- a/src/routes/organizations/routes/invite/module/index.js
+++ b/src/routes/organizations/routes/invite/module/index.js
@@ -1,0 +1,9 @@
+import { fetchInvite, setInvite, acceptInvite } from './actions'
+import reducer from './reducer'
+import sagas from './sagas'
+
+export { fetchInvite, setInvite, acceptInvite }
+
+export { sagas }
+
+export default reducer

--- a/src/routes/organizations/routes/invite/module/reducer.js
+++ b/src/routes/organizations/routes/invite/module/reducer.js
@@ -1,0 +1,25 @@
+import { createReducer } from '../../../../../util/reducer'
+import * as actions from './actions'
+
+export const INITIAL_STATE = {
+  invite: undefined,
+  acceptInProgress: false
+}
+
+const setInvite = (state, { payload: { invite } }) => ({
+  ...state,
+  invite,
+  acceptInProgress: false
+})
+
+const setAcceptInProgress = state => ({
+  ...state,
+  acceptInProgress: true
+})
+
+const ACTION_HANDLERS = {
+  [actions.SET_INVITE]: setInvite,
+  [actions.SET_ACCEPT_IN_PROGRESS]: setAcceptInProgress
+}
+
+export default createReducer(INITIAL_STATE, ACTION_HANDLERS)

--- a/src/routes/organizations/routes/invite/module/reducer.spec.js
+++ b/src/routes/organizations/routes/invite/module/reducer.spec.js
@@ -1,0 +1,66 @@
+import * as actions from './actions'
+import reducer from './reducer'
+
+export const INITIAL_STATE = {
+  invite: undefined,
+  acceptInProgress: false
+}
+
+describe('routes', () => {
+  describe('organizations', () => {
+    describe('routes', () => {
+      describe('invite', () => {
+        describe('reducer', () => {
+          it('defines an initial state', () => {
+            expect(reducer(undefined, {})).toEqual(INITIAL_STATE)
+          })
+
+          it('handles SET_INVITE action', () => {
+            expect(
+              reducer(
+                {
+                  invite: {
+                    firstname: 'Max',
+                    lastname: 'Muster'
+                  },
+                  acceptInProgress: true
+                },
+                actions.setInvite({
+                  firstname: 'Hans',
+                  lastname: 'Meier'
+                })
+              )
+            ).toEqual({
+              invite: {
+                firstname: 'Hans',
+                lastname: 'Meier'
+              },
+              acceptInProgress: false
+            })
+          })
+
+          it('handles SET_ACCEPT_IN_PROGRESS action', () => {
+            expect(
+              reducer(
+                {
+                  invite: {
+                    firstname: 'Max',
+                    lastname: 'Muster'
+                  },
+                  acceptInProgress: false
+                },
+                actions.setAcceptInProgress()
+              )
+            ).toEqual({
+              invite: {
+                firstname: 'Max',
+                lastname: 'Muster'
+              },
+              acceptInProgress: true
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/routes/organizations/routes/invite/module/sagas.js
+++ b/src/routes/organizations/routes/invite/module/sagas.js
@@ -1,0 +1,47 @@
+import { takeEvery, all, call, put, select } from 'redux-saga/effects'
+import * as actions from './actions'
+import { getFirestore } from '../../../../../util/firebase'
+import { getDoc, updateDoc } from '../../../../../util/firestoreUtils'
+
+export const uidSelector = state => state.firebase.auth.uid
+
+export function* getInvite(organizationId, inviteId) {
+  const firestore = yield call(getFirestore)
+  return yield call(firestore.get, {
+    collection: 'organizations',
+    doc: organizationId,
+    subcollections: [
+      {
+        collection: 'members',
+        doc: inviteId
+      }
+    ]
+  })
+}
+
+export function* fetchInvite({ payload: { organizationId, inviteId } }) {
+  const invite = yield call(getInvite, organizationId, inviteId)
+  const data = invite.exists ? invite.data() : null
+  yield put(actions.setInvite(data))
+}
+
+export function* acceptInvite({ payload: { organizationId, inviteId } }) {
+  yield put(actions.setAcceptInProgress())
+  const uid = yield select(uidSelector)
+  const user = yield call(getDoc, ['users', uid])
+  yield call(
+    updateDoc,
+    ['organizations', organizationId, 'members', inviteId],
+    {
+      user: user.ref
+    }
+  )
+  yield put(actions.fetchInvite(organizationId, inviteId))
+}
+
+export default function* sagas() {
+  yield all([
+    takeEvery(actions.FETCH_INVITE, fetchInvite),
+    takeEvery(actions.ACCEPT_INVITE, acceptInvite)
+  ])
+}

--- a/src/routes/organizations/routes/invite/module/sagas.spec.js
+++ b/src/routes/organizations/routes/invite/module/sagas.spec.js
@@ -1,0 +1,140 @@
+import { all, takeEvery, call, select } from 'redux-saga/effects'
+import { expectSaga } from 'redux-saga-test-plan'
+import { getDoc, updateDoc } from '../../../../../util/firestoreUtils'
+import { getFirestore } from '../../../../../util/firebase'
+import * as actions from './actions'
+import * as sagas from './sagas'
+
+describe('routes', () => {
+  describe('organizations', () => {
+    describe('routes', () => {
+      describe('invite', () => {
+        describe('sagas', () => {
+          describe('getInvite', () => {
+            it('should load invite', () => {
+              const orgId = 'my_org'
+              const inviteId = 'invite-id'
+
+              const invite = {
+                exists: true,
+                data: () => ({
+                  firstname: 'Max',
+                  lastname: 'Muster',
+                  deleted: false
+                })
+              }
+
+              const firestore = {
+                get: () => {}
+              }
+
+              return expectSaga(sagas.getInvite, orgId, inviteId)
+                .provide([
+                  [call(getFirestore), firestore],
+                  [
+                    call(firestore.get, {
+                      collection: 'organizations',
+                      doc: orgId,
+                      subcollections: [
+                        {
+                          collection: 'members',
+                          doc: inviteId
+                        }
+                      ]
+                    }),
+                    invite
+                  ]
+                ])
+                .returns(invite)
+                .run()
+            })
+          })
+
+          describe('fetchInvite', () => {
+            it('should fetch invite and set to store', () => {
+              const orgId = 'my_org'
+              const inviteId = 'invite-id'
+
+              const invite = {
+                exists: true,
+                data: () => ({
+                  firstname: 'Max',
+                  lastname: 'Muster',
+                  deleted: false
+                })
+              }
+
+              const action = actions.fetchInvite(orgId, inviteId)
+
+              return expectSaga(sagas.fetchInvite, action)
+                .provide([[call(sagas.getInvite, orgId, inviteId), invite]])
+                .put(actions.setInvite(invite.data()))
+                .run()
+            })
+
+            it('should fetch invite and set null if does not exist', () => {
+              const orgId = 'my_org'
+              const inviteId = 'invite-id'
+
+              const invite = {
+                exists: false
+              }
+
+              const action = actions.fetchInvite(orgId, inviteId)
+
+              return expectSaga(sagas.fetchInvite, action)
+                .provide([[call(sagas.getInvite, orgId, inviteId), invite]])
+                .put(actions.setInvite(null))
+                .run()
+            })
+          })
+
+          describe('acceptInvite', () => {
+            it('should set user on invite', () => {
+              const orgId = 'my_org'
+              const inviteId = 'invite-id'
+              const uid = 'user-id'
+
+              const user = {
+                ref: 'user-id'
+              }
+
+              const action = actions.acceptInvite(orgId, inviteId)
+
+              return expectSaga(sagas.acceptInvite, action)
+                .provide([
+                  [select(sagas.uidSelector), uid],
+                  [call(getDoc, ['users', uid]), user],
+                  [
+                    call(
+                      updateDoc,
+                      ['organizations', orgId, 'members', inviteId],
+                      {
+                        user: user.ref
+                      }
+                    )
+                  ]
+                ])
+                .put(actions.setAcceptInProgress())
+                .put(actions.fetchInvite(orgId, inviteId))
+                .run()
+            })
+          })
+
+          describe('default', () => {
+            it('should fork all sagas', () => {
+              const generator = sagas.default()
+
+              expect(generator.next().value).toEqual(
+                all([
+                  takeEvery(actions.FETCH_INVITE, sagas.fetchInvite),
+                  takeEvery(actions.ACCEPT_INVITE, sagas.acceptInvite)
+                ])
+              )
+            })
+          })
+        })
+      })
+    })
+  })
+})

--- a/src/routes/organizations/routes/invite/route.js
+++ b/src/routes/organizations/routes/invite/route.js
@@ -1,0 +1,12 @@
+import InvitePage from './components/InvitePage'
+import invite, { sagas as inviteSagas } from './module'
+import login, { sagas as loginSagas } from '../../../login/module'
+
+export default {
+  container: InvitePage,
+  reducers: {
+    invite,
+    login
+  },
+  sagas: [inviteSagas, loginSagas]
+}

--- a/src/routes/organizations/routes/invite/route.spec.js
+++ b/src/routes/organizations/routes/invite/route.spec.js
@@ -1,0 +1,25 @@
+import route from './route'
+import InvitePage from './components/InvitePage'
+import invite, { sagas as inviteSagas } from './module'
+import login, { sagas as loginSagas } from '../../../login/module'
+
+describe('routes', () => {
+  describe('organizations', () => {
+    describe('routes', () => {
+      describe('invite', () => {
+        describe('route', () => {
+          it('should export the right things', () => {
+            expect(route).toEqual({
+              container: InvitePage,
+              reducers: {
+                invite,
+                login
+              },
+              sagas: [inviteSagas, loginSagas]
+            })
+          })
+        })
+      })
+    })
+  })
+})


### PR DESCRIPTION
- Link for individual invitation page will be sent via email to a
  new organization member (not implemented yet)
- The new member who receives the invitation mail logs into the app
  using his personal Google account and clicks the "join" button.
  Once the user joins, he's redirected to the organization page
  where he can start to log his flights.