### PR TITLE
Send automatic invitation mails to organization members

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,17 @@ Query Parameters:
 * `fields`: Comma separated list of columns to include in the report (optional; all fields by default)
 
 **Note**: The requesting user must be a manager of the organization to be able to get the flights.
+
+## Cloud Functions Config
+
+### Organization Member Invitation Mail
+
+Set the following config options using the command `firebase function:config:set ${name}={value}`
+(e.g.`firebase functions:config:set invite.sender.port=465`)
+
+* `invite.sender.host`: SMTP host name (e.g. "smtp.mailgun.org")
+* `invite.sender.port`: SMTP port number (e.g. 465)
+* `invite.sender.user`: SMTP user name (e.g. "odch@xyz.mailgun.org")
+* `invite.sender.password`: Password of the SMTP user (e.g. "xyz123")
+* `invite.sender.email`: Address to send the invitation mail from (e.g. "noreply@opendigital.ch")
+* `invite.url`: Base web address for the invitation link in the mail (e.g. "https://logbook.opendigital.ch")

--- a/functions/organization/memberinvite.function.js
+++ b/functions/organization/memberinvite.function.js
@@ -1,0 +1,100 @@
+/* eslint-disable no-empty */
+const functions = require('firebase-functions')
+const admin = require('firebase-admin')
+const nodemailer = require('nodemailer')
+
+const config = functions.config()
+
+if (!config.invite || !config.invite.sender || !config.invite.sender.host) {
+  throw new Error(
+    'Required configuration property `invite.sender.host` not defined'
+  )
+}
+if (!config.invite.sender.port) {
+  throw new Error(
+    'Required configuration property `invite.sender.port` not defined'
+  )
+}
+if (!config.invite.sender.email) {
+  throw new Error(
+    'Required configuration property `invite.sender.email` not defined'
+  )
+}
+if (!config.invite.sender.user) {
+  throw new Error(
+    'Required configuration property `invite.sender.user` not defined'
+  )
+}
+if (!config.invite.sender.password) {
+  throw new Error(
+    'Required configuration property `invite.sender.password` not defined'
+  )
+}
+if (!config.invite.url) {
+  throw new Error('Required configuration property `invite.url` not defined')
+}
+
+// Prevent firebase from initializing twice
+try {
+  admin.initializeApp(functions.config().firebase)
+} catch (e) {}
+
+const transporter = nodemailer.createTransport({
+  host: config.invite.sender.host,
+  port: config.invite.sender.port,
+  secure: true,
+  auth: {
+    user: config.invite.sender.user,
+    pass: config.invite.sender.password
+  }
+})
+
+const sendMail = (inviteEmail, firstname, orgId, memberId) => {
+  console.log(
+    `sending invitation mail (to: ${inviteEmail}, firstname: ${firstname}, org id: ${orgId}, member id: ${memberId})`
+  )
+
+  const link = `${config.invite.url}/organizations/${orgId}/invite/${memberId}`
+
+  const html = `<h1>Hallo ${firstname}!</h1>
+     <p>Du wurdest eingeladen, der Organisation <strong>${orgId}</strong> beizutreten.</p>
+     <p><a href="${link}">Klicke hier</a>, um die Einladung anzunehmen.</p>`
+
+  const mailOptions = {
+    from: config.invite.sender.email,
+    to: inviteEmail,
+    subject: `Digitales Flugreisebuch: Einladung in Organisation ${orgId}`,
+    html
+  }
+
+  return transporter.sendMail(mailOptions)
+}
+
+const setTimestamp = memberRef =>
+  memberRef.set(
+    {
+      inviteTimestamp: admin.firestore.FieldValue.serverTimestamp()
+    },
+    { merge: true }
+  )
+
+const sendInvitation = change => {
+  const data = change.after.data()
+
+  if (data && data['inviteEmail'] && !data['inviteTimestamp']) {
+    const email = data['inviteEmail']
+    const firstname = data['firstname']
+    const orgId = change.after.ref.parent.parent.id
+    const memberId = change.after.ref.id
+
+    return sendMail(email, firstname, orgId, memberId).then(() =>
+      setTimestamp(change.after.ref)
+    )
+  }
+
+  return null
+}
+
+module.exports.sendInvitationOnMemberWrite = functions.firestore
+  .document('organizations/{organizationID}/members/{memberID}')
+  .onWrite(change => sendInvitation(change))

--- a/functions/package.json
+++ b/functions/package.json
@@ -18,7 +18,8 @@
     "fast-csv": "^3.4.0",
     "firebase-admin": "^8.4.0",
     "firebase-functions": "^3.2.0",
-    "glob": "^7.1.4"
+    "glob": "^7.1.4",
+    "nodemailer": "^6.3.1"
   },
   "private": true
 }

--- a/functions/yarn.lock
+++ b/functions/yarn.lock
@@ -1053,6 +1053,11 @@ node-forge@^0.8.0:
   resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.8.5.tgz#57906f07614dc72762c84cef442f427c0e1b86ee"
   integrity sha512-vFMQIWt+J/7FLNyKouZ9TazT74PRV3wgv9UT4cRjC8BffxFbKXkgIWR42URCPSnHm/QDz6BOlb2Q0U4+VQT67Q==
 
+nodemailer@^6.3.1:
+  version "6.3.1"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.3.1.tgz#2784beebac6b9f014c424c54dbdcc5c4d1221346"
+  integrity sha512-j0BsSyaMlyadEDEypK/F+xlne2K5m6wzPYMXS/yxKI0s7jmT1kBx6GEKRVbZmyYfKOsjkeC/TiMVDJBI/w5gMQ==
+
 object-assign@^4:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"


### PR DESCRIPTION
- The mail is sent when a user document is written (= created or updated)
  and if it contains a property called `inviteEmail` but no `inviteTimestamp`
- When the mail is sent, the current timestamp is set as `inviteTimestamp`
- So, to send a second invitation mail to a certain user, the `inviteTimestamp`
  can be deleted -> the resulting update event for the member document
  triggers the function that sends the mail
- The mail can be sent by any desired SMTP provider (e.g. mailgun).
  Just define the host and credentials via the Firebase function config.