### PR TITLE
Replace Firebase API key for production project

### DIFF
--- a/projects/prod.json
+++ b/projects/prod.json
@@ -1,6 +1,6 @@
 {
   "firebase": {
-    "apiKey": "AIzaSyD9wr8WTwIig5WhOU-R_jy097AEBma6hjI",
+    "apiKey": "AIzaSyC03RO4voBQIT8ttBINJy7ITtesLm5T3_M",
     "authDomain": "odch-aircraft-logbook-prod.firebaseapp.com",
     "databaseURL": "https://odch-aircraft-logbook-prod.firebaseio.com",
     "projectId": "odch-aircraft-logbook-prod",


### PR DESCRIPTION
Server key instead of browser key was used accidentally (existing key
now regenerated)