### PR TITLE
Make sure that no flight can be created with date prior to last flight

### DIFF
--- a/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
+++ b/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
@@ -19,34 +19,8 @@ const DATE_TIME_PATTERN = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}$/
  * @param aircraftSettings
  * @return a map containing the error message for the mapped fields
  */
-export default function* validateFlight(
-  data,
-  organizationId,
-  aircraftId,
-  aircraftSettings
-) {
-  let errors = yield call(
-    validateSync,
-    data,
-    organizationId,
-    aircraftId,
-    aircraftSettings
-  )
-
-  if (Object.keys(errors).length === 0) {
-    errors = yield call(
-      validateAsync,
-      data,
-      organizationId,
-      aircraftId,
-      aircraftSettings
-    )
-  }
-
-  return errors
-}
-
-export function validateSync(
+// eslint-disable-next-line require-yield
+export function* validateSync(
   data,
   organizationId,
   aircraftId,


### PR DESCRIPTION
If the same date as the date of the last flight was entered with a
block off time before the block on time of the last flight, this was
already recognized as invalid.
However, if the entered date was before the last flight, the block off
time of the new record was compared with the date of today instead of
the actually entered date. This issue is fixed now.