### PR TITLE
Fix entering date with keyboard in flight create dialog

### DIFF
--- a/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
@@ -323,7 +323,7 @@ class FlightCreateDialog extends React.Component {
         label={this.msg(`flight.create.dialog.${name.toLowerCase()}`)}
         value={this.getValue(name)}
         onChange={this.handleDateChange(name)}
-        format="L"
+        format="DD.MM.YYYY"
         data-cy={`${name}-field`}
         margin="normal"
         fullWidth


### PR DESCRIPTION
`format="L"` didn't work anymore: after typing the first digit,
no more digits were accepted.
By using "DD.MM.YYYY" as format, this is fixed.