### PR TITLE
Make `fuel uplift` field mandatory (however, value 0 is allowed too)

### DIFF
--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -108,7 +108,7 @@
   "flight.create.dialog.validation.counters.enginetimecounter.end.not_before_start_counter": "Endzähler darf nicht kleiner als Startzähler sein",
   "flight.create.dialog.validation.landings.required": "Bitte gültige Anzahl Landungen eingeben (mindestens eine)",
   "flight.create.dialog.validation.personsonboard.required": "Bitte gültige Anzahl Personen an Bord eingeben (mindestens eine)",
-  "flight.create.dialog.validation.fueluplift.invalid": "Bitte gültige Treibstoff-Menge eingeben",
+  "flight.create.dialog.validation.fueluplift.required": "Bitte gültige Treibstoff-Menge eingeben (0 oder grösser als 0)",
   "flight.create.dialog.validation.fueltype.required": "Bitte Treibstofftyp auswählen",
   "flight.create.dialog.validation.oiluplift.invalid": "Bitte gültige Öl-Menge eingeben",
   "flight.create.dialog.dateinvalid": "Datum im Format TT.MM.JJJJ eingeben (z.B. 07.09.2018)",

--- a/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
+++ b/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
@@ -76,13 +76,10 @@ export function* validateSync(
   if (typeof data.personsOnBoard !== 'number' || data.personsOnBoard < 1) {
     errors['personsOnBoard'] = 'required'
   }
-  if (data.fuelUplift) {
-    if (typeof data.fuelUplift !== 'number' || data.fuelUplift < 0) {
-      errors['fuelUplift'] = 'invalid'
-    }
-    if (!data.fuelType) {
-      errors['fuelType'] = 'required'
-    }
+  if (typeof data.fuelUplift !== 'number' || data.fuelUplift < 0) {
+    errors['fuelUplift'] = 'required'
+  } else if (data.fuelUplift > 0 && !data.fuelType) {
+    errors['fuelType'] = 'required'
   }
   if (
     data.oilUplift &&

--- a/src/routes/organizations/routes/aircraft/module/util/validateFlight.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/util/validateFlight.spec.js
@@ -431,12 +431,16 @@ describe('routes', () => {
               )
             })
 
+            it('should return an error if fuelUplift is missing', () => {
+              return testFn({}, aircraftSettings1, 'fuelUplift', 'required')
+            })
+
             it('should return an error if fuelUplift is not a number', () => {
               return testFn(
                 { fuelUplift: 'foobar' },
                 aircraftSettings1,
                 'fuelUplift',
-                'invalid'
+                'required'
               )
             })
 
@@ -445,7 +449,16 @@ describe('routes', () => {
                 { fuelUplift: -1 },
                 aircraftSettings1,
                 'fuelUplift',
-                'invalid'
+                'required'
+              )
+            })
+
+            it('should return no error if fuelUplift is 0', () => {
+              return testFn(
+                { fuelUplift: 0 },
+                aircraftSettings1,
+                'fuelUplift',
+                undefined
               )
             })
 
@@ -455,6 +468,15 @@ describe('routes', () => {
                 aircraftSettings1,
                 'fuelType',
                 'required'
+              )
+            })
+
+            it('should return no error if fuelUplift 0 and fuelType is missing', () => {
+              return testFn(
+                { fuelUplift: 0 },
+                aircraftSettings1,
+                'fuelType',
+                undefined
               )
             })
 


### PR DESCRIPTION
To prevent that users forget to enter the value.