### PR TITLE
Show description and status of troubles and observations in flight list

### DIFF
--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -103,6 +103,7 @@
   "flightlist.landings": "Landungen",
   "flightlist.personsonboard": "Personen an Bord (inkl. Pilot)",
   "flightlist.remarks": "Bemerkungen für Abrechnung",
+  "flightlist.troublesobservations": "Probleme oder Beobachtungen",
   "flightlist.delete": "Flug löschen",
   "flightlist.delete.not_newest": "Dieser Flug kann nicht mehr gelöscht werden, da bereits ein Folgeflug erfasst wurde.",
   "flightlist.total.flighthours": "Flugstunden total",

--- a/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
@@ -615,10 +615,13 @@ const flightDataShape = PropTypes.shape({
   oilUplift: PropTypes.number,
   remarks: PropTypes.string,
   troublesObservations: PropTypes.oneOf(['nil', 'troubles']),
-  techlogEntryStatus: PropTypes.shape({
-    value: PropTypes.string.isRequired,
-    label: PropTypes.string.isRequired
-  }),
+  techlogEntryStatus: PropTypes.oneOfType([
+    PropTypes.shape({
+      value: PropTypes.string.isRequired,
+      label: PropTypes.string.isRequired
+    }),
+    PropTypes.string
+  ]),
   techlogEntryDescription: PropTypes.string,
   techlogEntryAttachments: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.js
@@ -3,6 +3,8 @@ import { useIntl } from 'react-intl'
 import TextField from '@material-ui/core/TextField'
 import Grid from '@material-ui/core/Grid'
 import Divider from '@material-ui/core/Divider'
+import Box from '@material-ui/core/Box'
+import { EntryStatus } from '../Techlog'
 import { aircraft, flight } from '../../../../../../shapes'
 import {
   formatDate,
@@ -164,6 +166,27 @@ const FlightDetails = ({ aircraft, flight }) => {
           </Grid>
         )}
       </Grid>
+      {flight.troublesObservations && (
+        <Grid item xs={12} container>
+          <Grid item xs={12} sm={8}>
+            {flight.troublesObservations === 'nil' ? (
+              renderField('troublesobservations', 'NIL', intl)
+            ) : (
+              <>
+                {renderField(
+                  'troublesobservations',
+                  flight.techlogEntryDescription,
+                  intl,
+                  true
+                )}
+                <Box mb={1}>
+                  <EntryStatus id={flight.techlogEntryStatus} small />
+                </Box>
+              </>
+            )}
+          </Grid>
+        </Grid>
+      )}
       <Divider />
       <Grid item xs={12} container>
         <Grid item xs={6} sm={4}>

--- a/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.spec.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.spec.js
@@ -68,7 +68,10 @@ describe('routes', () => {
                 remarks: 'my\ntest\nremarks',
                 fuelUplift: 58.68,
                 fuelType: 'mogas_homebase',
-                oilUplift: 0.7
+                oilUplift: 0.7,
+                troublesObservations: 'troubles',
+                techlogEntryStatus: 'not_airworthy',
+                techlogEntryDescription: 'loose screw left main wheel'
               }
 
               const renderToJson = component =>

--- a/src/routes/organizations/routes/aircraft/components/FlightList/__snapshots__/FlightDetails.spec.js.snap
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/__snapshots__/FlightDetails.spec.js.snap
@@ -588,6 +588,72 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     />
   </div>
+  <div
+    className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+  >
+    <div
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+      >
+        <label
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+          data-shrink={true}
+        >
+          Probleme oder Beobachtungen
+        </label>
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-multiline MuiInput-multiline"
+          onClick={[Function]}
+        >
+          <textarea
+            aria-invalid={false}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
+            disabled={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            readOnly={true}
+            required={false}
+            rows={1}
+            style={
+              Object {
+                "height": undefined,
+                "overflow": null,
+              }
+            }
+            value="loose screw left main wheel"
+          />
+          <textarea
+            aria-hidden={true}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
+            readOnly={true}
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+                "visibility": "hidden",
+              }
+            }
+            tabIndex={-1}
+          />
+        </div>
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root-200"
+      >
+        <span
+          className="MuiTypography-root EntryStatus-status-160 EntryStatus-error-161 EntryStatus-small-163 MuiTypography-body1"
+        >
+          Nicht flugtauglich
+        </span>
+      </div>
+    </div>
+  </div>
   <hr
     className="MuiDivider-root"
   />
@@ -1278,6 +1344,72 @@ remarks"
     <div
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     />
+  </div>
+  <div
+    className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
+  >
+    <div
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+    >
+      <div
+        className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
+      >
+        <label
+          className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-formControl MuiInputLabel-animated MuiInputLabel-shrink MuiFormLabel-filled"
+          data-shrink={true}
+        >
+          Probleme oder Beobachtungen
+        </label>
+        <div
+          className="MuiInputBase-root MuiInput-root MuiInputBase-fullWidth MuiInput-fullWidth MuiInputBase-formControl MuiInput-formControl MuiInputBase-multiline MuiInput-multiline"
+          onClick={[Function]}
+        >
+          <textarea
+            aria-invalid={false}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
+            disabled={false}
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            readOnly={true}
+            required={false}
+            rows={1}
+            style={
+              Object {
+                "height": undefined,
+                "overflow": null,
+              }
+            }
+            value="loose screw left main wheel"
+          />
+          <textarea
+            aria-hidden={true}
+            className="MuiInputBase-input MuiInput-input MuiInputBase-inputMultiline MuiInput-inputMultiline"
+            readOnly={true}
+            style={
+              Object {
+                "height": 0,
+                "left": 0,
+                "overflow": "hidden",
+                "position": "absolute",
+                "top": 0,
+                "visibility": "hidden",
+              }
+            }
+            tabIndex={-1}
+          />
+        </div>
+      </div>
+      <div
+        className="MuiBox-root MuiBox-root-159"
+      >
+        <span
+          className="MuiTypography-root EntryStatus-status-160 EntryStatus-error-161 EntryStatus-small-163 MuiTypography-body1"
+        >
+          Nicht flugtauglich
+        </span>
+      </div>
+    </div>
   </div>
   <hr
     className="MuiDivider-root"

--- a/src/routes/organizations/routes/aircraft/components/Techlog/index.js
+++ b/src/routes/organizations/routes/aircraft/components/Techlog/index.js
@@ -1,3 +1,5 @@
 import Techlog from './Techlog'
+import EntryStatus from './EntryStatus'
 
 export default Techlog
+export { EntryStatus }

--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -313,7 +313,14 @@ export function* createFlight({
       fuelUnit: 'litre',
       oilUplift,
       oilUnit: 'litre',
-      remarks: data.remarks || null
+      remarks: data.remarks || null,
+      troublesObservations: data.troublesObservations,
+      techlogEntryDescription: data.techlogEntryDescription
+        ? data.techlogEntryDescription.trim()
+        : null,
+      techlogEntryStatus: data.techlogEntryStatus
+        ? data.techlogEntryStatus.value
+        : null
     }
 
     const oldFlightDoc = data.id
@@ -481,7 +488,10 @@ export function* openAndInitEditFlightDialog({
     fuelType,
     oilUplift,
     remarks,
-    counters
+    counters,
+    troublesObservations,
+    techlogEntryDescription,
+    techlogEntryStatus
   }) => ({
     id: flight.id,
     date: extractDate(blockOffTime, departureAerodrome.timezone),
@@ -500,7 +510,10 @@ export function* openAndInitEditFlightDialog({
     fuelType: fuelType ? getFuelTypeOption(fuelType) : null,
     oilUplift,
     remarks: remarks || '',
-    counters
+    counters,
+    troublesObservations,
+    techlogEntryDescription,
+    techlogEntryStatus
   }))(flight.data())
   yield put(
     actions.setInitialCreateFlightDialogData(

--- a/src/routes/organizations/routes/aircraft/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.spec.js
@@ -187,6 +187,7 @@ describe('routes', () => {
                 fuelType: { value: 'avgas_homebase' },
                 oilUplift: 245,
                 remarks: 'bemerkung zeile 1\nzeile2',
+                personsOnBoard: 1,
                 troublesObservations: 'troubles',
                 techlogEntryStatus: { value: 'not_airworthy' },
                 techlogEntryDescription: ' Schraube am Bugfahrwerkt locker\n  ',
@@ -380,7 +381,11 @@ describe('routes', () => {
                 fuelType: 'avgas_homebase',
                 oilUplift: 2.45,
                 oilUnit: 'litre',
-                remarks: 'bemerkung zeile 1\nzeile2'
+                remarks: 'bemerkung zeile 1\nzeile2',
+                personsOnBoard: 1,
+                troublesObservations: 'troubles',
+                techlogEntryStatus: 'not_airworthy',
+                techlogEntryDescription: 'Schraube am Bugfahrwerkt locker'
               }
 
               expect(generator.next(newFlightDoc).value).toEqual(

--- a/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
+++ b/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
@@ -155,7 +155,7 @@ export function* validateSync(
     }
   }
 
-  if (aircraftSettings.techlogEnabled === true && !data.id) {
+  if (aircraftSettings.techlogEnabled === true) {
     if (!data.troublesObservations) {
       errors['troublesObservations'] = 'required'
     }


### PR DESCRIPTION
To be able to show it, we also have to save it in the flight record
(wasn't the case before).

So, there are 3 new fields in the flight document:
- `troublesObservations`: mandatory, "nil" or "troubles"
- `techlogEntryStatus`: mandatory if `troublesObservations` is
                        "troubles" (string)
- `techlogEntryDescription`: mandatory if `troublesObservations` is
                             "troubles" (multiline text)