### PR TITLE
Fix organization member invite after breaking it with commit 6396620

### DIFF
--- a/src/modules/app/sagas.js
+++ b/src/modules/app/sagas.js
@@ -73,6 +73,9 @@ export function* getWithRoles(organizationDoc, userRef) {
 }
 
 export function* fetchOrganizations() {
+  // set to loading state
+  yield put(actions.setMyOrganizations(undefined))
+
   let organizations = []
 
   const uid = yield select(uidSelector)

--- a/src/modules/app/sagas.spec.js
+++ b/src/modules/app/sagas.spec.js
@@ -129,6 +129,10 @@ describe('modules', () => {
 
           const generator = sagas.fetchOrganizations()
 
+          expect(generator.next().value).toEqual(
+            put(actions.setMyOrganizations(undefined))
+          )
+
           expect(generator.next().value).toEqual(select(sagas.uidSelector))
 
           expect(generator.next('current-user-id').value).toEqual(
@@ -157,6 +161,10 @@ describe('modules', () => {
 
         it('should set empty array if user has no organizations', () => {
           const generator = sagas.fetchOrganizations()
+
+          expect(generator.next().value).toEqual(
+            put(actions.setMyOrganizations(undefined))
+          )
 
           expect(generator.next().value).toEqual(select(sagas.uidSelector))
 

--- a/src/routes/organizations/routes/invite/module/sagas.js
+++ b/src/routes/organizations/routes/invite/module/sagas.js
@@ -1,7 +1,12 @@
 import { takeEvery, all, call, put, select } from 'redux-saga/effects'
 import * as actions from './actions'
 import { getFirestore } from '../../../../../util/firebase'
-import { getDoc, updateDoc } from '../../../../../util/firestoreUtils'
+import {
+  getDoc,
+  updateDoc,
+  addArrayItem
+} from '../../../../../util/firestoreUtils'
+import { fetchOrganizations } from '../../../../../modules/app'
 
 export const uidSelector = state => state.firebase.auth.uid
 
@@ -36,6 +41,9 @@ export function* acceptInvite({ payload: { organizationId, inviteId } }) {
       user: user.ref
     }
   )
+  const org = yield call(getDoc, ['organizations', organizationId])
+  yield call(addArrayItem, ['users', user.id], 'organizations', org.ref)
+  yield put(fetchOrganizations())
   yield put(actions.fetchInvite(organizationId, inviteId))
 }
 

--- a/src/routes/organizations/routes/invite/module/sagas.spec.js
+++ b/src/routes/organizations/routes/invite/module/sagas.spec.js
@@ -1,9 +1,14 @@
 import { all, takeEvery, call, select } from 'redux-saga/effects'
 import { expectSaga } from 'redux-saga-test-plan'
-import { getDoc, updateDoc } from '../../../../../util/firestoreUtils'
+import {
+  addArrayItem,
+  getDoc,
+  updateDoc
+} from '../../../../../util/firestoreUtils'
 import { getFirestore } from '../../../../../util/firebase'
 import * as actions from './actions'
 import * as sagas from './sagas'
+import { fetchOrganizations } from '../../../../../modules/app'
 
 describe('routes', () => {
   describe('organizations', () => {
@@ -96,7 +101,13 @@ describe('routes', () => {
               const uid = 'user-id'
 
               const user = {
-                ref: 'user-id'
+                id: uid,
+                ref: { id: uid }
+              }
+
+              const org = {
+                id: orgId,
+                ref: { id: orgId }
               }
 
               const action = actions.acceptInvite(orgId, inviteId)
@@ -113,9 +124,12 @@ describe('routes', () => {
                         user: user.ref
                       }
                     )
-                  ]
+                  ],
+                  [call(getDoc, ['organizations', orgId]), org],
+                  [call(addArrayItem, ['users', uid], 'organizations', org.ref)]
                 ])
                 .put(actions.setAcceptInProgress())
+                .put(fetchOrganizations())
                 .put(actions.fetchInvite(orgId, inviteId))
                 .run()
             })


### PR DESCRIPTION
Organizations in the client aren't watched continuously anymore.
We have to initiate fetching the organizations by ourselves, when they
change. Also, we should add the organization reference in the
user doc by ourselves, as the server side trigger that updates the
references is delayed (trigger will be removed probably).