### PR TITLE
Fix landing time calc. when dest. aerodrome created in flight dialog

### DIFF
--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -593,7 +593,8 @@ export function* createAerodrome({
       actions.updateCreateFlightDialogData({
         [fieldName]: {
           value: doc.id,
-          label: `${data.identification} (${data.name})`
+          label: `${data.identification} (${data.name})`,
+          timezone: data.timezone.value
         }
       })
     )

--- a/src/routes/organizations/routes/aircraft/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.spec.js
@@ -792,16 +792,18 @@ describe('routes', () => {
             const data = {
               identification: 'LSXX',
               name: 'Hagenbuch',
-              timezone: 'Europe/Zurich'
+              timezone: {
+                value: 'Europe/Zurich'
+              }
             }
 
             const action = actions.createAerodrome(orgId, fieldName, data)
 
             it('should create the aerodrome in the organization', () => {
               const expectedDataToStore = {
-                identification: data.identification,
-                name: data.name,
-                timezone: data.timezone.value,
+                identification: 'LSXX',
+                name: 'Hagenbuch',
+                timezone: 'Europe/Zurich',
                 deleted: false
               }
 
@@ -825,7 +827,8 @@ describe('routes', () => {
                   actions.updateCreateFlightDialogData({
                     [fieldName]: {
                       value: 'newAerodromeId',
-                      label: 'LSXX (Hagenbuch)'
+                      label: 'LSXX (Hagenbuch)',
+                      timezone: 'Europe/Zurich'
                     }
                   })
                 )


### PR DESCRIPTION
The timezone of the newly created aerodrome wasn't added to the field
value in the create flight dialog data. For this reason, the landing
time couldn't be calculated.