### PR TITLE
Fix cypress test `organizations_spec`

### DIFF
--- a/cypress/integration/organizations_spec.js
+++ b/cypress/integration/organizations_spec.js
@@ -31,9 +31,7 @@ context('Organizations', () => {
       '[data-cy=organization-create-dialog] [data-cy=create-button]'
     ).click()
 
-    cy.get('[data-cy=organizations-list]')
-      .contains(orgName, { timeout: 10000 })
-      .click()
+    cy.get(`[data-cy=organization-${orgName}]`).click()
 
     cy.get('[data-cy=user-button]').click()
     cy.get('[data-cy=menu-item-selected-organization-settings]').click()

--- a/src/routes/organizations/components/OrganizationsList/OrganizationsList.js
+++ b/src/routes/organizations/components/OrganizationsList/OrganizationsList.js
@@ -90,7 +90,10 @@ class OrganizationsList extends React.Component {
         )}
         {organizations.map(organization => (
           <Grid item key={organization.id} sm={4} xs={12}>
-            <Card className={classes.card}>
+            <Card
+              className={classes.card}
+              data-cy={`organization-${organization.id}`}
+            >
               <CardActionArea
                 className={classes.actionArea}
                 component={Link}

--- a/src/routes/organizations/components/OrganizationsList/__snapshots__/OrganizationsList.spec.js.snap
+++ b/src/routes/organizations/components/OrganizationsList/__snapshots__/OrganizationsList.spec.js.snap
@@ -19,21 +19,21 @@ exports[`components OrganizationsList renders organizations if loaded 1`] = `
       </button></div>
   </div>
   <div class=\\"MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4\\">
-    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-2 MuiPaper-rounded\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-4\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org1\\">
+    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-2 MuiPaper-rounded\\" data-cy=\\"organization-org1\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-4\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org1\\">
         <div class=\\"MuiCardContent-root OrganizationsList-cardContent-3\\">
           <h6 class=\\"MuiTypography-root MuiTypography-h6\\">org1</h6>
         </div><span class=\\"MuiCardActionArea-focusHighlight\\"></span><span class=\\"MuiTouchRipple-root\\"></span>
       </a></div>
   </div>
   <div class=\\"MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4\\">
-    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-2 MuiPaper-rounded\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-4\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org2\\">
+    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-2 MuiPaper-rounded\\" data-cy=\\"organization-org2\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-4\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org2\\">
         <div class=\\"MuiCardContent-root OrganizationsList-cardContent-3\\">
           <h6 class=\\"MuiTypography-root MuiTypography-h6\\">org2</h6>
         </div><span class=\\"MuiCardActionArea-focusHighlight\\"></span><span class=\\"MuiTouchRipple-root\\"></span>
       </a></div>
   </div>
   <div class=\\"MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4\\">
-    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-2 MuiPaper-rounded\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-4\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org3\\">
+    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-2 MuiPaper-rounded\\" data-cy=\\"organization-org3\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-4\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org3\\">
         <div class=\\"MuiCardContent-root OrganizationsList-cardContent-3\\">
           <h6 class=\\"MuiTypography-root MuiTypography-h6\\">org3</h6>
         </div><span class=\\"MuiCardActionArea-focusHighlight\\"></span><span class=\\"MuiTouchRipple-root\\"></span>

--- a/src/routes/organizations/components/OrganizationsPage/__snapshots__/OrganizationsPage.spec.js.snap
+++ b/src/routes/organizations/components/OrganizationsPage/__snapshots__/OrganizationsPage.spec.js.snap
@@ -17,21 +17,21 @@ exports[`components OrganizationsPage renders correctly 1`] = `
       </button></div>
   </div>
   <div class=\\"MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4\\">
-    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-100 MuiPaper-rounded\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-102\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org1\\">
+    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-100 MuiPaper-rounded\\" data-cy=\\"organization-org1\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-102\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org1\\">
         <div class=\\"MuiCardContent-root OrganizationsList-cardContent-101\\">
           <h6 class=\\"MuiTypography-root MuiTypography-h6\\">org1</h6>
         </div><span class=\\"MuiCardActionArea-focusHighlight\\"></span><span class=\\"MuiTouchRipple-root\\"></span>
       </a></div>
   </div>
   <div class=\\"MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4\\">
-    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-100 MuiPaper-rounded\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-102\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org2\\">
+    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-100 MuiPaper-rounded\\" data-cy=\\"organization-org2\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-102\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org2\\">
         <div class=\\"MuiCardContent-root OrganizationsList-cardContent-101\\">
           <h6 class=\\"MuiTypography-root MuiTypography-h6\\">org2</h6>
         </div><span class=\\"MuiCardActionArea-focusHighlight\\"></span><span class=\\"MuiTouchRipple-root\\"></span>
       </a></div>
   </div>
   <div class=\\"MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4\\">
-    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-100 MuiPaper-rounded\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-102\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org3\\">
+    <div class=\\"MuiPaper-root MuiPaper-elevation1 MuiCard-root OrganizationsList-card-100 MuiPaper-rounded\\" data-cy=\\"organization-org3\\"><a class=\\"MuiButtonBase-root MuiCardActionArea-root OrganizationsList-actionArea-102\\" tabindex=\\"0\\" role=\\"button\\" href=\\"/organizations/org3\\">
         <div class=\\"MuiCardContent-root OrganizationsList-cardContent-101\\">
           <h6 class=\\"MuiTypography-root MuiTypography-h6\\">org3</h6>
         </div><span class=\\"MuiCardActionArea-focusHighlight\\"></span><span class=\\"MuiTouchRipple-root\\"></span>


### PR DESCRIPTION
The newly created organization couldn't be selected anymore with
the selector `cy.get('[data-cy=organizations-list]').contains(orgName)`.
To fix this selection issue, we add a data-cy attribute on the
organization card itself and select it directly.