### PR TITLE
Fix editing flights on page that shows all flights of an aircraft

### DIFF
--- a/src/routes/organizations/routes/aircraft/routes/flights/containers/FlightListContainer.js
+++ b/src/routes/organizations/routes/aircraft/routes/flights/containers/FlightListContainer.js
@@ -11,6 +11,7 @@ import {
   fetchFlights,
   openCreateFlightDialog,
   initCreateFlightDialog,
+  openEditFlightDialog,
   openDeleteFlightDialog,
   closeDeleteFlightDialog,
   deleteFlight
@@ -49,6 +50,7 @@ const mapActionCreators = {
   changeFlightsPage,
   openCreateFlightDialog,
   initCreateFlightDialog,
+  openEditFlightDialog,
   openDeleteFlightDialog,
   closeDeleteFlightDialog,
   deleteFlight


### PR DESCRIPTION
The action to open the editing dialog was missing in this list.