### PR TITLE
Fix saving flights with deactivated techlog

### DIFF
--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -311,12 +311,15 @@ export function* createFlight({
       oilUnit: 'litre',
       remarks: data.remarks || null,
       preflightCheck:
-        typeof data.preflightCheck === 'boolean' ? data.preflightCheck : null,
-      troublesObservations: data.troublesObservations,
-      techlogEntryDescription: data.techlogEntryDescription
+        typeof data.preflightCheck === 'boolean' ? data.preflightCheck : null
+    }
+
+    if (data.troublesObservations) {
+      dataToStore.troublesObservations = data.troublesObservations
+      dataToStore.techlogEntryDescription = data.techlogEntryDescription
         ? data.techlogEntryDescription.trim()
-        : null,
-      techlogEntryStatus: data.techlogEntryStatus
+        : null
+      dataToStore.techlogEntryStatus = data.techlogEntryStatus
         ? data.techlogEntryStatus.value
         : null
     }


### PR DESCRIPTION
If the techlog is not enabled `troublesObservations` is `undefined`,
which leads to an error when we try to save the flight in firestore.