### PR TITLE
Fix editing flights with techlog entry

### DIFF
--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -320,7 +320,9 @@ export function* createFlight({
         ? data.techlogEntryDescription.trim()
         : null
       dataToStore.techlogEntryStatus = data.techlogEntryStatus
-        ? data.techlogEntryStatus.value
+        ? typeof data.techlogEntryStatus === 'string'
+          ? data.techlogEntryStatus
+          : data.techlogEntryStatus.value
         : null
     }
 
@@ -343,7 +345,7 @@ export function* createFlight({
       dataToStore
     )
 
-    if (data.troublesObservations === 'troubles') {
+    if (data.troublesObservations === 'troubles' && !data.id) {
       const entry = {
         description: data.techlogEntryDescription.trim(),
         initialStatus: data.techlogEntryStatus.value,


### PR DESCRIPTION
- In this case, `data.techlogEntryStatus` is a string (not object with
  property `value`)
- Furthermore, we don't want to create another techlog entry if it's
  an update operation (flight.id is set in this case)