### PR TITLE
Fix disabling scrolling in number components

### DIFF
--- a/src/components/DecimalField/DecimalField.js
+++ b/src/components/DecimalField/DecimalField.js
@@ -9,8 +9,12 @@ class DecimalField extends React.Component {
     stringValue:
       typeof this.props.value === 'number'
         ? formatWithTwoDecimals(this.props.value / 100)
-        : '',
-    focused: false
+        : ''
+  }
+
+  constructor(props) {
+    super(props)
+    this.numberInput = React.createRef()
   }
 
   handleChange = e => {
@@ -20,22 +24,24 @@ class DecimalField extends React.Component {
   }
 
   handleFocus = () => {
-    this.setState({
-      focused: true
+    this.numberInput.current.addEventListener('wheel', this.handleWheel, {
+      passive: false // important to register as active listener to be able to use `preventDefault` in handle wheel
     })
   }
 
   handleBlur = () => {
     const { onChange } = this.props
 
-    const newState = {
-      focused: false
-    }
+    this.numberInput.current.removeEventListener('wheel', this.handleWheel)
 
     const floatValue = parseFloat(this.state.stringValue)
     if (!isNaN(floatValue)) {
       const twoDecimals = Math.round(floatValue * 100) / 100
-      newState.stringValue = formatWithTwoDecimals(twoDecimals)
+      const stringValue = formatWithTwoDecimals(twoDecimals)
+
+      this.setState({
+        stringValue
+      })
 
       if (onChange) {
         const hundredths = Math.round(twoDecimals * 100)
@@ -44,14 +50,10 @@ class DecimalField extends React.Component {
     } else if (this.state.stringValue === '' && onChange) {
       onChange(null)
     }
-
-    this.setState(newState)
   }
 
   handleWheel = e => {
-    if (this.state.focused === true) {
-      e.preventDefault() // prevent number from being changed by scrolling
-    }
+    e.preventDefault() // prevent number from being changed by scrolling
   }
 
   render() {
@@ -64,7 +66,7 @@ class DecimalField extends React.Component {
         onChange={this.handleChange}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
-        onWheel={this.handleWheel}
+        inputRef={this.numberInput}
         type="number"
         inputProps={{ step: '.01' }}
         data-cy={cy}

--- a/src/components/IntegerField/IntegerField.js
+++ b/src/components/IntegerField/IntegerField.js
@@ -3,8 +3,9 @@ import PropTypes from 'prop-types'
 import TextField from '@material-ui/core/TextField'
 
 class IntegerField extends React.Component {
-  state = {
-    focused: false
+  constructor(props) {
+    super(props)
+    this.numberInput = React.createRef()
   }
 
   handleChange = e => {
@@ -18,21 +19,17 @@ class IntegerField extends React.Component {
   }
 
   handleFocus = () => {
-    this.setState({
-      focused: true
+    this.numberInput.current.addEventListener('wheel', this.handleWheel, {
+      passive: false // important to register as active listener to be able to use `preventDefault` in handle wheel
     })
   }
 
   handleBlur = () => {
-    this.setState({
-      focused: false
-    })
+    this.numberInput.current.removeEventListener('wheel', this.handleWheel)
   }
 
   handleWheel = e => {
-    if (this.state.focused === true) {
-      e.preventDefault() // prevent number from being changed by scrolling
-    }
+    e.preventDefault() // prevent number from being changed by scrolling
   }
 
   render() {
@@ -44,7 +41,7 @@ class IntegerField extends React.Component {
         onChange={this.handleChange}
         onFocus={this.handleFocus}
         onBlur={this.handleBlur}
-        onWheel={this.handleWheel}
+        inputRef={this.numberInput}
         cy={cy}
         type="number"
         margin={margin}


### PR DESCRIPTION
- It is really annoying that the value in number fields is changed by
  scrolling, which is why we disabled it in the first place.
- However, `e.preventDefault()` in the `handleWheel` handler didn't
  work anymore. It failed with the following error message in the cons.:
  "[Intervention] Unable to preventDefault inside passive event
  listener due to target being treated as passive."
- To fix this issue, we have to register the `handleWheel` event
  listener as *active* listener by registering the event handler
  with `passive: false`.