### PR TITLE
Fix editing members with minimal data (without nr and invite email)

### DIFF
--- a/src/routes/organizations/routes/settings/module/reducer.js
+++ b/src/routes/organizations/routes/settings/module/reducer.js
@@ -134,10 +134,10 @@ const openEditMemberDialog = (state, { payload: { member } }) => ({
     data: {
       firstname: member.firstname,
       lastname: member.lastname,
-      nr: member.nr,
+      nr: member.nr || '',
       roles: member.roles || [],
       instructor: member.instructor || false,
-      inviteEmail: member.inviteEmail
+      inviteEmail: member.inviteEmail || ''
     }
   }
 })

--- a/src/routes/organizations/routes/settings/module/reducer.spec.js
+++ b/src/routes/organizations/routes/settings/module/reducer.spec.js
@@ -299,6 +299,47 @@ describe('routes', () => {
             })
           })
 
+          it('handles OPEN_EDIT_MEMBER_DIALOG action with minimal data', () => {
+            const member = {
+              firstname: 'Max',
+              lastname: 'Keller'
+            }
+
+            expect(
+              reducer(
+                {
+                  editMemberDialog: {
+                    open: false,
+                    submitting: true,
+                    data: {
+                      firstname: 'Hans',
+                      lastname: 'Meier',
+                      nr: '242',
+                      roles: ['user'],
+                      instructor: true,
+                      inviteEmail: 'hans.meier@test.com'
+                    }
+                  }
+                },
+                actions.openEditMemberDialog(member)
+              )
+            ).toEqual({
+              editMemberDialog: {
+                open: true,
+                submitting: false,
+                member,
+                data: {
+                  firstname: 'Max',
+                  lastname: 'Keller',
+                  nr: '',
+                  roles: [],
+                  instructor: false,
+                  inviteEmail: ''
+                }
+              }
+            })
+          })
+
           it('handles CLOSE_EDIT_MEMBER_DIALOG action', () => {
             expect(
               reducer(


### PR DESCRIPTION
Before, those fields were set to `undefined` and if we tried to save the
member with those fields unchanged it resulted in a firestore error.