### PR TITLE
Show troubles/observations section even if techlog not enabled

### DIFF
--- a/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
@@ -224,8 +224,7 @@ class FlightCreateDialog extends React.Component {
       aircraftSettings: {
         fuelTypes,
         engineHoursCounterEnabled,
-        engineHoursCounterFractionDigits,
-        techlogEnabled
+        engineHoursCounterFractionDigits
       }
     } = this.props
 
@@ -291,7 +290,7 @@ class FlightCreateDialog extends React.Component {
             {this.renderDecimalField('oilUplift')}
             {this.renderMultilineTextField('remarks')}
             {this.renderCheckbox('preflightCheck')}
-            {techlogEnabled && this.renderObservationsSection()}
+            {this.renderObservationsSection()}
           </DialogContent>
           <DialogActions>
             <Button onClick={onClose} color="primary" disabled={submitting}>
@@ -562,7 +561,13 @@ class FlightCreateDialog extends React.Component {
   }
 
   renderObservationsSection() {
-    const { techlogEntryStatusOptions, data, submitting, classes } = this.props
+    const {
+      techlogEntryStatusOptions,
+      data,
+      submitting,
+      aircraftSettings: { techlogEnabled },
+      classes
+    } = this.props
     const value = data.troublesObservations || ''
     return this.renderInFormControl(
       'troublesObservations',
@@ -591,25 +596,30 @@ class FlightCreateDialog extends React.Component {
           </RadioGroup>
           {value === 'troubles' && (
             <>
-              {this.renderSelect(
-                'techlogEntryStatus',
-                techlogEntryStatusOptions
-              )}
-              {this.renderMultilineTextField('techlogEntryDescription', 5)}
-              <Attachments
-                attachments={data.techlogEntryAttachments}
-                disabled={submitting}
-                onRemoveClick={this.removeAttachment}
-                className={classes.techlogEntryAttachments}
-              />
-              <FileButton
-                disabled={submitting}
-                label={this.msg(
-                  'flight.create.dialog.techlogentryattachment.add'
+              {techlogEnabled &&
+                this.renderSelect(
+                  'techlogEntryStatus',
+                  techlogEntryStatusOptions
                 )}
-                onSelect={this.handleFileSelect}
-                className={classes.addTechlogEntryAttachmentButton}
-              />
+              {this.renderMultilineTextField('techlogEntryDescription', 5)}
+              {techlogEnabled && (
+                <>
+                  <Attachments
+                    attachments={data.techlogEntryAttachments}
+                    disabled={submitting}
+                    onRemoveClick={this.removeAttachment}
+                    className={classes.techlogEntryAttachments}
+                  />
+                  <FileButton
+                    disabled={submitting}
+                    label={this.msg(
+                      'flight.create.dialog.techlogentryattachment.add'
+                    )}
+                    onSelect={this.handleFileSelect}
+                    className={classes.addTechlogEntryAttachmentButton}
+                  />
+                </>
+              )}
             </>
           )}
         </>

--- a/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.js
@@ -195,9 +195,11 @@ const FlightDetails = ({ aircraft, flight }) => {
                   intl,
                   true
                 )}
-                <Box mb={1}>
-                  <EntryStatus id={flight.techlogEntryStatus} small />
-                </Box>
+                {flight.techlogEntryStatus && (
+                  <Box mb={1}>
+                    <EntryStatus id={flight.techlogEntryStatus} small />
+                  </Box>
+                )}
               </>
             )}
           </Grid>

--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -319,11 +319,13 @@ export function* createFlight({
       dataToStore.techlogEntryDescription = data.techlogEntryDescription
         ? data.techlogEntryDescription.trim()
         : null
-      dataToStore.techlogEntryStatus = data.techlogEntryStatus
-        ? typeof data.techlogEntryStatus === 'string'
-          ? data.techlogEntryStatus
-          : data.techlogEntryStatus.value
-        : null
+      if (aircraftSettings.techlogEnabled === true) {
+        dataToStore.techlogEntryStatus = data.techlogEntryStatus
+          ? typeof data.techlogEntryStatus === 'string'
+            ? data.techlogEntryStatus
+            : data.techlogEntryStatus.value
+          : null
+      }
     }
 
     const oldFlightDoc = data.id
@@ -345,7 +347,11 @@ export function* createFlight({
       dataToStore
     )
 
-    if (data.troublesObservations === 'troubles' && !data.id) {
+    if (
+      data.troublesObservations === 'troubles' &&
+      !data.id &&
+      aircraftSettings.techlogEnabled === true
+    ) {
       const entry = {
         description: data.techlogEntryDescription.trim(),
         initialStatus: data.techlogEntryStatus.value,

--- a/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
+++ b/src/routes/organizations/routes/aircraft/module/util/validateFlight.js
@@ -167,20 +167,15 @@ export function* validateSync(
     errors['preflightCheck'] = 'required'
   }
 
-  if (aircraftSettings.techlogEnabled === true) {
-    if (!data.troublesObservations) {
-      errors['troublesObservations'] = 'required'
+  if (!data.troublesObservations) {
+    errors['troublesObservations'] = 'required'
+  }
+  if (data.troublesObservations === 'troubles') {
+    if (aircraftSettings.techlogEnabled === true && !data.techlogEntryStatus) {
+      errors['techlogEntryStatus'] = 'required'
     }
-    if (data.troublesObservations === 'troubles') {
-      if (!data.techlogEntryStatus) {
-        errors['techlogEntryStatus'] = 'required'
-      }
-      if (
-        !data.techlogEntryDescription ||
-        !data.techlogEntryDescription.trim()
-      ) {
-        errors['techlogEntryDescription'] = 'required'
-      }
+    if (!data.techlogEntryDescription || !data.techlogEntryDescription.trim()) {
+      errors['techlogEntryDescription'] = 'required'
     }
   }
 

--- a/src/routes/organizations/routes/aircraft/module/util/validateFlight.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/util/validateFlight.spec.js
@@ -656,6 +656,60 @@ describe('routes', () => {
                 undefined
               )
             })
+
+            it('should return an error if troublesObservations is missing', () => {
+              return testFn(
+                {},
+                aircraftSettings1,
+                'troublesObservations',
+                'required'
+              )
+            })
+
+            it('should return no error if troublesObservations is set', () => {
+              return testFn(
+                {
+                  troublesObservations: 'nil'
+                },
+                aircraftSettings1,
+                'troublesObservations',
+                undefined
+              )
+            })
+
+            it('should return an error if not nil and techlogEntryDescription is missing', () => {
+              return testFn(
+                {
+                  troublesObservations: 'troubles'
+                },
+                aircraftSettings1,
+                'techlogEntryDescription',
+                'required'
+              )
+            })
+
+            it('should return no error if nil and techlogEntryDescription not set', () => {
+              return testFn(
+                {
+                  troublesObservations: 'nil'
+                },
+                aircraftSettings1,
+                'techlogEntryDescription',
+                undefined
+              )
+            })
+
+            it('should return no error if not nil and techlogEntryDescription is set', () => {
+              return testFn(
+                {
+                  troublesObservations: 'troubles',
+                  techlogEntryDescription: 'my description'
+                },
+                aircraftSettings1,
+                'techlogEntryDescription',
+                undefined
+              )
+            })
           })
 
           describe('validateAsync', () => {


### PR DESCRIPTION
If the techlog is not enabled, there is only the nil/troubles radio
group in the flight creation dialog where the pilot has to choose one
option. If he selects "troubles", he has to enter a description (there
is no status field and there are no attachments). The text description
is written to the flight record without creating an additional techlog
entry (just like in the paper book).