### PR TITLE
Increase timeout for deletion of test user in cypress tests

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -11,7 +11,7 @@ Cypress.Commands.add('logout', () =>
 )
 
 Cypress.Commands.add('deleteTestUser', () =>
-  cy.window().then(win => {
+  cy.window().then({ timeout: 10000 }, win => {
     const deleteTestUser = win.firebase
       .functions()
       .httpsCallable('deleteTestUser')


### PR DESCRIPTION
Test fails frequently, because calling the 'deleteTestUser' cloud
function sometimes takes more than 4s (default timeout).