### PR TITLE
Add serial number to techlog entries

### DIFF
--- a/src/routes/organizations/routes/aircraft/components/AircraftDetail/AircraftDetail.spec.js
+++ b/src/routes/organizations/routes/aircraft/components/AircraftDetail/AircraftDetail.spec.js
@@ -114,6 +114,7 @@ describe('routes', () => {
                     ],
                     'techlog-o7flC7jw8jmkOfWo8oyA-open': [
                       {
+                        number: '1',
                         description: 'Schraube am Bugfahrwerk locker',
                         author: {
                           firstname: 'Hans',

--- a/src/routes/organizations/routes/aircraft/components/AircraftDetail/__snapshots__/AircraftDetail.spec.js.snap
+++ b/src/routes/organizations/routes/aircraft/components/AircraftDetail/__snapshots__/AircraftDetail.spec.js.snap
@@ -96,6 +96,15 @@ exports[`routes organizations routes aircraft components AircraftDetail renders 
           className="MuiExpansionPanelSummary-content"
         >
           <div
+            className="Techlog-entryNumber-71"
+          >
+            <p
+              className="MuiTypography-root Techlog-entryNumberText-72 MuiTypography-body1"
+            >
+              #1
+            </p>
+          </div>
+          <div
             className="Techlog-entryHeading-70"
           >
             <p
@@ -105,13 +114,13 @@ exports[`routes organizations routes aircraft components AircraftDetail renders 
               <br />
             </p>
             <span
-              className="MuiTypography-root EntryStatus-status-115 EntryStatus-severe-116 MuiTypography-body1"
+              className="MuiTypography-root EntryStatus-status-117 EntryStatus-severe-118 MuiTypography-body1"
             >
               Defect (not airworthy)
             </span>
           </div>
           <p
-            className="MuiTypography-root Techlog-entrySecondaryHeading-71 MuiTypography-body1"
+            className="MuiTypography-root Techlog-entrySecondaryHeading-73 MuiTypography-body1"
           >
             Hans
              
@@ -232,7 +241,7 @@ exports[`routes organizations routes aircraft components AircraftDetail renders 
     </span>
   </button>
   <div
-    className="FlightList-container-144"
+    className="FlightList-container-146"
   >
     <div
       className="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-rounded"
@@ -261,20 +270,20 @@ exports[`routes organizations routes aircraft components AircraftDetail renders 
           className="MuiExpansionPanelSummary-content"
         >
           <div
-            className="FlightList-flightHeading-145"
+            className="FlightList-flightHeading-147"
           >
             <p
               className="MuiTypography-root MuiTypography-body1"
             >
               Von 
               <span
-                className="FlightList-bold-147"
+                className="FlightList-bold-149"
               >
                 LSZT
               </span>
                nach 
               <span
-                className="FlightList-bold-147"
+                className="FlightList-bold-149"
               >
                 LSZT
               </span>
@@ -282,7 +291,7 @@ exports[`routes organizations routes aircraft components AircraftDetail renders 
             </p>
           </div>
           <p
-            className="MuiTypography-root FlightList-flightSecondaryHeading-146 MuiTypography-body1"
+            className="MuiTypography-root FlightList-flightSecondaryHeading-148 MuiTypography-body1"
           >
             20.11.2018
             ,

--- a/src/routes/organizations/routes/aircraft/components/Techlog/Techlog.js
+++ b/src/routes/organizations/routes/aircraft/components/Techlog/Techlog.js
@@ -40,6 +40,14 @@ const styles = theme => ({
     display: 'block',
     flex: 1
   },
+  entryNumber: {
+    marginRight: '1em',
+    paddingRight: '1em',
+    borderRight: `1px solid ${theme.palette.divider}`
+  },
+  entryNumberText: {
+    fontWeight: 'bold'
+  },
   entrySecondaryHeading: {
     fontSize: theme.typography.pxToRem(15),
     color: theme.palette.text.secondary,
@@ -163,6 +171,7 @@ class Techlog extends React.Component {
     const { organization, aircraft, authToken, classes } = this.props
     const {
       id,
+      number,
       description,
       currentStatus,
       timestamp,
@@ -178,6 +187,11 @@ class Techlog extends React.Component {
             : null
         }
       >
+        <div className={classes.entryNumber}>
+          <Typography
+            className={classes.entryNumberText}
+          >{`#${number}`}</Typography>
+        </div>
         <div className={classes.entryHeading}>
           <Typography paragraph className={classes.description}>
             {description.split('\n').map((line, idx) => (


### PR DESCRIPTION
- Last number (which is also the total count) is fetched from the
  field `counters.techlogEntries` from the aircraft document
- This number gets incremented and then used as the serial number for
  the new techlog entry and set as the new techlog entries count
  (everything happens in a transaction)