### PR TITLE
Allow org manager to update "for information only" techlog entry

### DIFF
--- a/src/routes/organizations/routes/aircraft/components/Techlog/Techlog.js
+++ b/src/routes/organizations/routes/aircraft/components/Techlog/Techlog.js
@@ -86,8 +86,16 @@ class Techlog extends React.Component {
 
   msg = id => this.props.intl.formatMessage({ id })
 
-  isTechlogManager = () =>
-    this.props.organization.roles.includes('techlogmanager')
+  hasRole = role => this.props.organization.roles.includes(role)
+
+  isTechlogManager = () => this.hasRole('techlogmanager')
+
+  isOrganizationManager = () => this.hasRole('manager')
+
+  hasActionCreatePermission = entry =>
+    this.isTechlogManager() ||
+    (this.isOrganizationManager() &&
+      entry.currentStatus === 'for_information_only')
 
   render() {
     const {
@@ -138,7 +146,7 @@ class Techlog extends React.Component {
           )}
           {createTechlogEntryActionDialogOpen && (
             <TechlogEntryActionCreateDialog
-              organizationId={organization.id}
+              organization={organization}
               aircraftId={aircraft.id}
             />
           )}
@@ -230,7 +238,7 @@ class Techlog extends React.Component {
             authToken={authToken}
           />
         </ExpansionPanelDetails>
-        {this.isTechlogManager() && (
+        {this.hasActionCreatePermission(entry) && (
           <React.Fragment>
             <Divider />
             <ExpansionPanelActions>

--- a/src/routes/organizations/routes/aircraft/components/TechlogEntryActionCreateDialog/TechlogEntryActionCreateDialog.js
+++ b/src/routes/organizations/routes/aircraft/components/TechlogEntryActionCreateDialog/TechlogEntryActionCreateDialog.js
@@ -11,7 +11,10 @@ import CircularProgress from '@material-ui/core/CircularProgress'
 import Checkbox from '@material-ui/core/Checkbox'
 import FormControlLabel from '@material-ui/core/FormControlLabel'
 import { withStyles } from '@material-ui/core/styles'
-import { intl as intlShape } from '../../../../../../shapes'
+import {
+  intl as intlShape,
+  organization as organizationShape
+} from '../../../../../../shapes'
 import Select from '../../../../../../components/Select'
 import Attachments from '../Attachments'
 import FileButton from '../FileButton'
@@ -83,7 +86,7 @@ class TechlogEntryActionCreateDialog extends React.Component {
   handleSubmit = e => {
     const {
       onSubmit,
-      organizationId,
+      organization,
       aircraftId,
       techlogEntryId,
       data,
@@ -92,7 +95,7 @@ class TechlogEntryActionCreateDialog extends React.Component {
 
     e.preventDefault()
     if (submitting !== true && onSubmit) {
-      onSubmit(organizationId, aircraftId, techlogEntryId, data)
+      onSubmit(organization.id, aircraftId, techlogEntryId, data)
     }
   }
 
@@ -218,7 +221,7 @@ class TechlogEntryActionCreateDialog extends React.Component {
 }
 
 TechlogEntryActionCreateDialog.propTypes = {
-  organizationId: PropTypes.string.isRequired,
+  organization: organizationShape.isRequired,
   aircraftId: PropTypes.string.isRequired,
   techlogEntryId: PropTypes.string.isRequired,
   statusOptions: PropTypes.arrayOf(

--- a/src/routes/organizations/routes/aircraft/containers/TechlogEntryActionCreateDialogContainer.js
+++ b/src/routes/organizations/routes/aircraft/containers/TechlogEntryActionCreateDialogContainer.js
@@ -7,7 +7,7 @@ import {
   closeCreateTechlogEntryActionDialog,
   createTechlogEntryAction
 } from '../module'
-import { getTechlogStatus } from '../../../../../util/techlogStatus'
+import { getTechlogActionStatus } from '../../../../../util/techlogStatus'
 import { aircraftSettings } from '../util/flightDialogUtils'
 
 const statusOption = (intl, statusId) => ({
@@ -15,11 +15,16 @@ const statusOption = (intl, statusId) => ({
   label: intl.formatMessage({ id: `techlog.entry.status.${statusId}` })
 })
 
-const techlogEntryStatus = intl =>
-  getTechlogStatus(true).map(status => statusOption(intl, status.id))
+const isTechlogManager = organization =>
+  organization.roles.includes('techlogmanager')
+
+const techlogEntryStatus = (organization, intl) =>
+  getTechlogActionStatus(isTechlogManager(organization)).map(status =>
+    statusOption(intl, status.id)
+  )
 
 const mapStateToProps = (state, ownProps) => {
-  const { aircraftId, intl } = ownProps
+  const { organization, aircraftId, intl } = ownProps
 
   const {
     techlogEntryId,
@@ -32,7 +37,7 @@ const mapStateToProps = (state, ownProps) => {
   }
 
   return {
-    statusOptions: techlogEntryStatus(intl),
+    statusOptions: techlogEntryStatus(organization, intl),
     techlogEntryId,
     data,
     submitting,

--- a/src/util/techlogStatus.js
+++ b/src/util/techlogStatus.js
@@ -14,6 +14,13 @@ export const getTechlogStatus = isTechlogManager =>
     ? STATUS.slice(0)
     : STATUS.filter(status => status.requiresManager === false)
 
+export const getTechlogActionStatus = isTechlogManager =>
+  isTechlogManager
+    ? getTechlogStatus(true)
+    : STATUS.filter(status =>
+        ['for_information_only', 'closed'].includes(status.id)
+      )
+
 export const getOpenTechlogStatus = () =>
   STATUS.filter(
     status => status.closed === false && status.requiresManager === false

--- a/src/util/techlogStatus.spec.js
+++ b/src/util/techlogStatus.spec.js
@@ -33,6 +33,36 @@ describe('util', () => {
       })
     })
 
+    describe('getTechlogActionStatus', () => {
+      it('should return all status if techlog manager', () => {
+        expect(techlogStatus.getTechlogActionStatus(true)).toEqual([
+          { id: 'for_information_only', closed: false, requiresManager: false },
+          { id: 'defect_aog', closed: false, requiresManager: false },
+          { id: 'defect_unknown', closed: false, requiresManager: false },
+          {
+            id: 'defect_with_limitations',
+            closed: false,
+            requiresManager: true
+          },
+          {
+            id: 'defect_not_flight_relevant',
+            closed: false,
+            requiresManager: true
+          },
+          { id: 'closed', closed: true, requiresManager: true },
+          { id: 'crs', closed: true, requiresManager: true },
+          { id: 'arc', closed: true, requiresManager: true }
+        ])
+      })
+
+      it('should return for_information_only and closed if not techlog manager', () => {
+        expect(techlogStatus.getTechlogActionStatus(false)).toEqual([
+          { id: 'for_information_only', closed: false, requiresManager: false },
+          { id: 'closed', closed: true, requiresManager: true }
+        ])
+      })
+    })
+
     describe('isClosed', () => {
       it('should return true if it is a closed status', () => {
         expect(techlogStatus.isClosed('closed')).toEqual(true)


### PR DESCRIPTION
Techlog entries with status "for information only" are the only ones
that can be updated by the organization manager. And he can only set
it to "closed" or keep the "for information only" status.
For all other status changes, the role "techlogmanager" is required.