### PR TITLE
Fix how the lock date is stored

### DIFF
--- a/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightCreateDialog/FlightCreateDialog.js
@@ -197,10 +197,7 @@ class FlightCreateDialog extends React.Component {
     if (!lockDate) {
       return undefined
     }
-
-    const minDate = new Date(lockDate)
-    minDate.setDate(lockDate.getDate() + 1)
-    return minDate
+    return lockDate
   }
 
   natureOption = id => ({

--- a/src/routes/organizations/routes/settings/components/LockDateForm/LockDateForm.js
+++ b/src/routes/organizations/routes/settings/components/LockDateForm/LockDateForm.js
@@ -1,15 +1,37 @@
 import React from 'react'
 import PropTypes from 'prop-types'
+import moment from 'moment-timezone'
 import { FormattedMessage, injectIntl } from 'react-intl'
 import Typography from '@material-ui/core/Typography'
 import { KeyboardDatePicker } from '@material-ui/pickers'
 import { intl as intlShape } from '../../../../../../shapes'
 
 class LockDateForm extends React.Component {
+  getDate = () => {
+    const date = this.props.date
+    if (!date) {
+      return null
+    }
+
+    // we have to subtract 1 day because we want flights to be editable *after* that day
+    // (so it's stored with time 00:00 of the *next* day in the Firestore database)
+    return moment(date).subtract(1, 'days').toDate()
+  }
+
+  toDateString = momentDate => {
+    if (!momentDate) {
+      return null
+    }
+
+    // we have to add 1 day because we want flights to be editable *after* that day
+    // (is stored with time 00:00 in the Firestore database)
+    return momentDate.add(1, 'days').format('YYYY-MM-DD')
+  }
+
   handleDateChange = momentDate => {
     const { organizationId, updateDate } = this.props
     if (!momentDate || momentDate.isValid() === true) {
-      const newDate = momentDate ? momentDate.format('YYYY-MM-DD') : null
+      const newDate = this.toDateString(momentDate)
       updateDate(organizationId, newDate)
     }
   }
@@ -27,7 +49,7 @@ class LockDateForm extends React.Component {
         </Typography>
         <KeyboardDatePicker
           label={this.msg('organization.settings.lockdate')}
-          value={this.props.date}
+          value={this.getDate()}
           onChange={this.handleDateChange}
           disabled={this.props.submitting}
           format="DD.MM.YYYY"

--- a/src/routes/organizations/routes/settings/components/OrganizationSettings/OrganizationSettings.spec.js
+++ b/src/routes/organizations/routes/settings/components/OrganizationSettings/OrganizationSettings.spec.js
@@ -68,7 +68,9 @@ describe('routes', () => {
                       {
                         id: 'my_org',
                         roles: ['manager'],
-                        lockDate: { toDate: () => new Date('2020-11-04') }
+                        lockDate: {
+                          toDate: () => new Date(2020, 10, 5, 0, 0, 0)
+                        }
                       }
                     ]
                   }


### PR DESCRIPTION
If the Firestore timestamp is created from the date string '2020-11-05',
it is actually stored as '2020-11-05 00:00:00'.

This is not what we want, because then the comparison of the flight date
in the security rules does not work:
`aircraftDoc.data.settings.lockDate.toMillis() < res.data.blockOffTime.toMillis()`

If we set the 2020-11-05 as lock date, we want everything to be forbidden
*including* 2020-11-05.

Therefore, we have to store the date as `2020-11-06 00:00:00` to make
the security rules condition work.