### PR TITLE
Add support for readonly access to an organization via sharing link

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -16,6 +16,10 @@ function isOrgManager(database, organization) {
   return isAuthed() && 'manager' in get(/databases/$(database)/documents/users/$(request.auth.uid)).data.orgs[organization].roles;
 }
 
+function isReadonlyOrgUser(organization) {
+  return isAuthed() && request.auth.uid == 'readonly' && request.auth.token.organization == organization
+}
+
 function affectsOnly(fields) {
   return request.resource.data.diff(resource.data).affectedKeys().hasOnly(fields);
 }
@@ -56,11 +60,11 @@ service cloud.firestore {
     }
 
     match /organizations/{organization} {
-      allow read: if isOrgMember(database, organization);
+      allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
       allow update: if isOrgManager(database, organization);
 
       match /members/{member} {
-        allow read: if isOrgMember(database, organization);
+        allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
         allow create: if isOrgManager(database, organization)
           && hasOnly(["deleted", "firstname", "lastname", "nr", "instructor", "roles", "inviteEmail", "inviteTimestamp", "createdBy", "createTimestamp", "updatedBy", "updateTimestamp"]);
         allow update: if isOrgManager(database, organization)
@@ -68,12 +72,12 @@ service cloud.firestore {
       }
 
       match /aircrafts/{aircraft} {
-        allow read: if isOrgMember(database, organization);
+        allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
         allow create: if isOrgManager(database, organization);
         allow update: if isOrgManager(database, organization) && affectsOnly(["deleted", "settings"]);
 
         match /flights/{flight} {
-          allow read: if isOrgMember(database, organization);
+          allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
 
           allow update: if isOrgMember(database, organization)
             && affectsOnly(["deleted", "deleteTimestamp", "deletedBy"])
@@ -81,20 +85,20 @@ service cloud.firestore {
         }
 
         match /techlog/{entry} {
-          allow read: if isOrgMember(database, organization);
+          allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
 
           match /actions/{action} {
-            allow read: if isOrgMember(database, organization);
+            allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
           }
         }
 
         match /checks/{check} {
-          allow read: if isOrgMember(database, organization);
+          allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
         }
       }
 
       match /aerodromes/{aerodrome} {
-        allow read: if isOrgMember(database, organization);
+        allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
         allow create: if isOrgMember(database, organization);
       }
     }

--- a/functions/auth/getReadonlyToken.function.js
+++ b/functions/auth/getReadonlyToken.function.js
@@ -1,0 +1,31 @@
+const functions = require('firebase-functions')
+const admin = require('firebase-admin')
+
+// Prevent firebase from initializing twice
+try {
+  admin.initializeApp(functions.config().firebase)
+  // eslint-disable-next-line no-empty
+} catch (e) {}
+
+const db = admin.firestore()
+
+const getReadonlyToken = functions.https.onCall(async data => {
+  const {
+    token: { orgId, token }
+  } = data
+  const doc = await db.collection('organizations').doc(orgId).get()
+
+  if (
+    doc.exists === true &&
+    doc.get('readonlyAccessToken') === token &&
+    doc.get('readonlyAccessEnabled') === true
+  ) {
+    return admin.auth().createCustomToken('readonly', {
+      organization: orgId
+    })
+  }
+
+  return null
+})
+
+exports.getReadonlyToken = getReadonlyToken

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -64,7 +64,7 @@ class Header extends React.Component {
               <img src={logo} className={classes.logo} />
             </Link>
           </Typography>
-          {!auth.isEmpty && (
+          {!auth.isEmpty && auth.uid !== 'readonly' && (
             <div>
               <IconButton
                 data-cy="user-button"
@@ -91,6 +91,7 @@ class Header extends React.Component {
 Header.propTypes = {
   auth: PropTypes.shape({
     isEmpty: PropTypes.bool.isRequired,
+    uid: PropTypes.string.isRequired,
     email: PropTypes.string
   }).isRequired,
   classes: PropTypes.object.isRequired

--- a/src/components/Header/Header.spec.js
+++ b/src/components/Header/Header.spec.js
@@ -39,5 +39,18 @@ describe('components', () => {
       ).toJSON()
       expect(tree).toMatchSnapshot()
     })
+
+    it('does not render user button if readonly user', () => {
+      const auth = {
+        isEmpty: false,
+        uid: 'readonly'
+      }
+      const tree = renderIntl(
+        <Router>
+          <Header auth={auth} logout={() => {}} />
+        </Router>
+      ).toJSON()
+      expect(tree).toMatchSnapshot()
+    })
   })
 })

--- a/src/components/Header/__snapshots__/Header.spec.js.snap
+++ b/src/components/Header/__snapshots__/Header.spec.js.snap
@@ -25,6 +25,31 @@ exports[`components Header does not render user button if not logged in 1`] = `
 </header>
 `;
 
+exports[`components Header does not render user button if readonly user 1`] = `
+<header
+  className="MuiPaper-root MuiPaper-elevation4 MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary"
+>
+  <div
+    className="MuiToolbar-root MuiToolbar-regular Header-container-6 MuiToolbar-gutters"
+  >
+    <h6
+      className="MuiTypography-root Header-grow-2 MuiTypography-h6 MuiTypography-colorInherit"
+    >
+      <a
+        className="Header-homeLink-4"
+        href="/"
+        onClick={[Function]}
+      >
+        <img
+          className="Header-logo-5"
+          src="test-file-stub"
+        />
+      </a>
+    </h6>
+  </div>
+</header>
+`;
+
 exports[`components Header renders user button if logged in 1`] = `
 <header
   className="MuiPaper-root MuiPaper-elevation4 MuiAppBar-root MuiAppBar-positionStatic MuiAppBar-colorPrimary"

--- a/src/components/ProtectedRoute/ProtectedRoute.js
+++ b/src/components/ProtectedRoute/ProtectedRoute.js
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { Route, Redirect } from 'react-router-dom'
 import { connect } from 'react-redux'
+import getAuthQueryToken from '../../util/getAuthQueryToken'
 
 const ProtectedRoute = ({ render, protect, authed, ...rest }) => (
   <Route
@@ -12,7 +13,13 @@ const ProtectedRoute = ({ render, protect, authed, ...rest }) => (
       }
       return (
         <Redirect
-          to={{ pathname: '/login', state: { from: props.location } }}
+          to={{
+            pathname: '/login',
+            state: {
+              from: props.location,
+              queryToken: getAuthQueryToken(props.location)
+            }
+          }}
         />
       )
     }}

--- a/src/messages/de.json
+++ b/src/messages/de.json
@@ -7,6 +7,7 @@
   "login.registration": "Noch kein Konto? Hier registrieren!",
   "login.or": "oder",
   "login.google": "Mit Google anmelden",
+  "login.tokeninvalid": "Link ungültig",
   "registration.firstname": "Vorname",
   "registration.lastname": "Nachname",
   "registration.email": "E-Mail",

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -7,6 +7,7 @@
   "login.registration": "No account yet? Register here!",
   "login.or": "or",
   "login.google": "Sign in with Google",
+  "login.tokeninvalid": "Link invalid",
   "registration.firstname": "First name",
   "registration.lastname": "Last name",
   "registration.email": "E-mail",

--- a/src/modules/app/sagas.js
+++ b/src/modules/app/sagas.js
@@ -22,13 +22,22 @@ export function* onLogin() {
   if (!uid) {
     throw 'UID not available'
   }
-  yield call(firestore.setListener, {
-    collection: 'users',
-    doc: uid,
-    storeAs: 'currentUser'
-  })
-
-  yield put(actions.fetchOrganizations())
+  if (uid === 'readonly') {
+    const user = firebase.auth().currentUser
+    const idTokenResult = yield call({
+      context: user,
+      fn: user.getIdTokenResult
+    })
+    const org = idTokenResult.claims.organization
+    yield put(actions.setMyOrganizations([{ id: org, readonly: true }]))
+  } else {
+    yield call(firestore.setListener, {
+      collection: 'users',
+      doc: uid,
+      storeAs: 'currentUser'
+    })
+    yield put(actions.fetchOrganizations())
+  }
 }
 
 export function* unwatchCurrentUser() {

--- a/src/modules/app/sagas.spec.js
+++ b/src/modules/app/sagas.spec.js
@@ -58,6 +58,30 @@ describe('modules', () => {
 
           expect(generator.next().done).toEqual(true)
         })
+
+        it('should set the readonly organization if readonly user', () => {
+          const firebase = {
+            updateProfile: () => {},
+            auth: () => ({
+              currentUser: {
+                getIdTokenResult: () => ({
+                  claims: {
+                    organization: 'mfgt'
+                  }
+                })
+              }
+            })
+          }
+
+          return expectSaga(sagas.onLogin)
+            .provide([
+              [call(getFirebase), firebase],
+              [call(getFirestore), {}],
+              [select(sagas.uidSelector), 'readonly']
+            ])
+            .put(actions.setMyOrganizations([{ id: 'mfgt', readonly: true }]))
+            .run()
+        })
       })
 
       describe('unwatchCurrentUser', () => {

--- a/src/routes/login/components/LoginPage/LoginPage.spec.js
+++ b/src/routes/login/components/LoginPage/LoginPage.spec.js
@@ -7,10 +7,51 @@ import configureStore from 'redux-mock-store'
 import LoginPage from './LoginPage'
 
 const StartPage = () => <div>start page</div>
+const OrgDetailPage = () => <div>org detail page</div>
 
 describe('components', () => {
   describe('LoginPage', () => {
-    it('redirects to start page if authenticated', () => {
+    it('redirects to from state if authenticated', () => {
+      const router = {
+        location: {
+          state: {
+            from: {
+              pathname: '/organizations/foobar'
+            }
+          }
+        }
+      }
+      const auth = {
+        isEmpty: false
+      }
+      const store = configureStore()({
+        firebase: {
+          auth
+        }
+      })
+      const tree = renderer
+        .create(
+          <Provider store={store}>
+            <Router>
+              <Switch>
+                <Route
+                  exact
+                  path="/organizations/foobar"
+                  component={OrgDetailPage}
+                />
+                <LoginPage auth={auth} router={router} />
+              </Switch>
+            </Router>
+          </Provider>
+        )
+        .toJSON()
+      expect(tree).toMatchSnapshot()
+    })
+
+    it('redirects to start page as default if authenticated', () => {
+      const router = {
+        location: {}
+      }
       const auth = {
         isEmpty: false
       }
@@ -25,7 +66,7 @@ describe('components', () => {
             <Router>
               <Switch>
                 <Route exact path="/" component={StartPage} />
-                <LoginPage auth={auth} />
+                <LoginPage auth={auth} router={router} />
               </Switch>
             </Router>
           </Provider>
@@ -38,6 +79,10 @@ describe('components', () => {
       const auth = {
         isEmpty: true
       }
+      const tokenLogin = {
+        submitted: false,
+        failed: false
+      }
       const store = configureStore()({
         firebase: {
           auth
@@ -49,14 +94,18 @@ describe('components', () => {
           submitted: false,
           googleLogin: {
             failed: false
-          }
+          },
+          tokenLogin
         }
       })
+      const router = {
+        location: {}
+      }
       const tree = renderIntl(
         <Provider store={store}>
           <Router>
             <Switch>
-              <LoginPage auth={auth} />
+              <LoginPage auth={auth} tokenLogin={tokenLogin} router={router} />
               <Route exact path="/" component={StartPage} />
             </Switch>
           </Router>

--- a/src/routes/login/components/LoginPage/__snapshots__/LoginPage.spec.js.snap
+++ b/src/routes/login/components/LoginPage/__snapshots__/LoginPage.spec.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`components LoginPage redirects to start page if authenticated 1`] = `
+exports[`components LoginPage redirects to from state if authenticated 1`] = `
+<div>
+  org detail page
+</div>
+`;
+
+exports[`components LoginPage redirects to start page as default if authenticated 1`] = `
 <div>
   start page
 </div>
@@ -8,13 +14,13 @@ exports[`components LoginPage redirects to start page if authenticated 1`] = `
 
 exports[`components LoginPage renders login form if not authenticated 1`] = `
 <main
-  className="LoginPage-layout-1"
+  className="LoginPage-layout-7"
 >
   <div
-    className="LoginPage-google-3"
+    className="LoginPage-google-9"
   >
     <button
-      className="MuiButtonBase-root MuiButton-root GoogleLogin-button-5 MuiButton-contained MuiButton-sizeLarge MuiButton-fullWidth"
+      className="MuiButtonBase-root MuiButton-root GoogleLogin-button-11 MuiButton-contained MuiButton-sizeLarge MuiButton-fullWidth"
       disabled={false}
       onBlur={[Function]}
       onClick={[Function]}
@@ -36,7 +42,7 @@ exports[`components LoginPage renders login form if not authenticated 1`] = `
       >
         <img
           alt="Google Logo"
-          className="GoogleLogin-logo-6"
+          className="GoogleLogin-logo-12"
           src="test-file-stub"
         />
         Mit Google anmelden
@@ -153,7 +159,7 @@ exports[`components LoginPage renders login form if not authenticated 1`] = `
   </form>
   <a
     aria-disabled={false}
-    className="MuiButtonBase-root MuiButton-root LoginPage-registrationButton-2 MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
+    className="MuiButtonBase-root MuiButton-root LoginPage-registrationButton-8 MuiButton-text MuiButton-textPrimary MuiButton-fullWidth"
     data-cy="registration"
     href="/register"
     onBlur={[Function]}

--- a/src/routes/login/containers/LoginPageContainer.js
+++ b/src/routes/login/containers/LoginPageContainer.js
@@ -1,10 +1,14 @@
 import { connect } from 'react-redux'
 import LoginPage from '../components/LoginPage'
+import { loginWithToken } from '../module'
 
 const mapStateToProps = (state /*, ownProps*/) => ({
-  auth: state.firebase.auth
+  auth: state.firebase.auth,
+  tokenLogin: state.login.tokenLogin
 })
 
-const mapDispatchToProps = (/*dispatch, ownProps*/) => ({})
+const mapActionCreators = {
+  loginWithToken
+}
 
-export default connect(mapStateToProps, mapDispatchToProps)(LoginPage)
+export default connect(mapStateToProps, mapActionCreators)(LoginPage)

--- a/src/routes/login/containers/LoginPageContainer.spec.js
+++ b/src/routes/login/containers/LoginPageContainer.spec.js
@@ -18,6 +18,9 @@ describe('containers', () => {
       const store = configureStore()({
         firebase: {
           auth: {}
+        },
+        login: {
+          tokenLogin: {}
         }
       })
 
@@ -35,7 +38,7 @@ describe('containers', () => {
     })
 
     it('should map state to props', () => {
-      const expectedPropKeys = ['auth']
+      const expectedPropKeys = ['auth', 'tokenLogin']
 
       expect(Object.keys(component.props)).toEqual(
         expect.arrayContaining(expectedPropKeys)
@@ -43,7 +46,7 @@ describe('containers', () => {
     })
 
     it('should map dispatch to props', () => {
-      const expectedPropKeys = []
+      const expectedPropKeys = ['loginWithToken']
 
       expect(Object.keys(component.props)).toEqual(
         expect.arrayContaining(expectedPropKeys)

--- a/src/routes/login/module/actions.js
+++ b/src/routes/login/module/actions.js
@@ -6,6 +6,8 @@ export const LOGIN_FAILURE = 'login/LOGIN_FAILURE'
 export const SET_SUBMITTED = 'login/SET_SUBMITTED'
 export const LOGIN_GOOGLE = 'login/LOGIN_GOOGLE'
 export const LOGIN_GOOGLE_FAILURE = 'login/LOGIN_GOOGLE_FAILURE'
+export const LOGIN_WITH_TOKEN = 'login/LOGIN_WITH_TOKEN'
+export const TOKEN_LOGIN_FAILURE = 'login/TOKEN_LOGIN_FAILURE'
 
 export const setUsername = username => ({
   type: SET_USERNAME,
@@ -47,4 +49,15 @@ export const loginGoogle = () => ({
 
 export const loginGoogleFailure = () => ({
   type: LOGIN_GOOGLE_FAILURE
+})
+
+export const loginWithToken = token => ({
+  type: LOGIN_WITH_TOKEN,
+  payload: {
+    token
+  }
+})
+
+export const tokenLoginFailure = () => ({
+  type: TOKEN_LOGIN_FAILURE
 })

--- a/src/routes/login/module/index.js
+++ b/src/routes/login/module/index.js
@@ -3,12 +3,20 @@ import {
   setPassword,
   login,
   setSubmitted,
-  loginGoogle
+  loginGoogle,
+  loginWithToken
 } from './actions'
 import reducer from './reducer'
 import sagas from './sagas'
 
-export { setUsername, setPassword, login, setSubmitted, loginGoogle }
+export {
+  setUsername,
+  setPassword,
+  login,
+  setSubmitted,
+  loginGoogle,
+  loginWithToken
+}
 
 export { sagas }
 

--- a/src/routes/login/module/reducer.js
+++ b/src/routes/login/module/reducer.js
@@ -8,6 +8,10 @@ export const INITIAL_STATE = {
   submitted: false,
   googleLogin: {
     failed: false
+  },
+  tokenLogin: {
+    failed: false,
+    submitted: false
   }
 }
 
@@ -51,13 +55,31 @@ const loginGoogleFailure = state => {
   })
 }
 
+const setTokenLoginSubmitted = state => ({
+  ...state,
+  tokenLogin: {
+    submitted: true,
+    failed: false
+  }
+})
+
+const tokenLoginFailure = state => ({
+  ...state,
+  tokenLogin: {
+    submitted: false,
+    failed: true
+  }
+})
+
 const ACTION_HANDLERS = {
   [actions.SET_USERNAME]: setUsername,
   [actions.SET_PASSWORD]: setPassword,
   [actions.LOGIN_SUCCESS]: loginSuccess,
   [actions.LOGIN_FAILURE]: loginFailure,
   [actions.SET_SUBMITTED]: setSubmitted,
-  [actions.LOGIN_GOOGLE_FAILURE]: loginGoogleFailure
+  [actions.LOGIN_GOOGLE_FAILURE]: loginGoogleFailure,
+  [actions.LOGIN_WITH_TOKEN]: setTokenLoginSubmitted,
+  [actions.TOKEN_LOGIN_FAILURE]: tokenLoginFailure
 }
 
 export default createReducer(INITIAL_STATE, ACTION_HANDLERS)

--- a/src/routes/login/module/reducer.spec.js
+++ b/src/routes/login/module/reducer.spec.js
@@ -8,6 +8,10 @@ const INITIAL_STATE = {
   submitted: false,
   googleLogin: {
     failed: false
+  },
+  tokenLogin: {
+    failed: false,
+    submitted: false
   }
 }
 
@@ -65,6 +69,48 @@ describe('modules', () => {
           username: 'foo',
           googleLogin: {
             failed: true
+          }
+        })
+      })
+
+      it('handles LOGIN_WITH_TOKEN action', () => {
+        expect(
+          reducer(
+            {
+              username: 'foo',
+              tokenLogin: {
+                failed: false,
+                submitted: false
+              }
+            },
+            actions.loginWithToken()
+          )
+        ).toEqual({
+          username: 'foo',
+          tokenLogin: {
+            failed: false,
+            submitted: true
+          }
+        })
+      })
+
+      it('handles TOKEN_LOGIN_FAILURE action', () => {
+        expect(
+          reducer(
+            {
+              username: 'foo',
+              tokenLogin: {
+                failed: false,
+                submitted: true
+              }
+            },
+            actions.tokenLoginFailure()
+          )
+        ).toEqual({
+          username: 'foo',
+          tokenLogin: {
+            failed: true,
+            submitted: false
           }
         })
       })

--- a/src/routes/organizations/routes/aircraft/components/FlightList/FlightList.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/FlightList.js
@@ -84,6 +84,8 @@ class FlightList extends React.Component {
     )
   }
 
+  hasWritePermissions = () => this.props.organization.readonly !== true
+
   componentDidMount() {
     const {
       organization,
@@ -165,21 +167,23 @@ class FlightList extends React.Component {
     return (
       <React.Fragment>
         <div className={classes.buttonsContainer}>
-          <Button
-            variant="contained"
-            color="primary"
-            onClick={this.handleCreateClick}
-            className={classes.button}
-            data-cy="flight-create-button"
-          >
-            <FormattedMessage
-              id={
-                this.newestFlightIsPreflight()
-                  ? 'aircraftdetail.completeflight'
-                  : 'aircraftdetail.createflight'
-              }
-            />
-          </Button>
+          {this.hasWritePermissions() && (
+            <Button
+              variant="contained"
+              color="primary"
+              onClick={this.handleCreateClick}
+              className={classes.button}
+              data-cy="flight-create-button"
+            >
+              <FormattedMessage
+                id={
+                  this.newestFlightIsPreflight()
+                    ? 'aircraftdetail.completeflight'
+                    : 'aircraftdetail.createflight'
+                }
+              />
+            </Button>
+          )}
           {this.isTechlogManager() &&
             flights.length > 0 &&
             !this.newestFlightIsPreflight() && (
@@ -306,7 +310,7 @@ class FlightList extends React.Component {
             <FlightDetails aircraft={aircraft} flight={flight} />
           )}
         </ExpansionPanelDetails>
-        {flight.deleted === false && (
+        {organization.readonly !== true && flight.deleted === false && (
           <>
             <Divider key={`divider-${flight.id}`} />
             <ExpansionPanelActions key={`actions-${flight.id}`}>

--- a/src/routes/organizations/routes/aircraft/components/FlightList/FlightList.spec.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/FlightList.spec.js
@@ -8,88 +8,111 @@ describe('routes', () => {
       describe('aircraft', () => {
         describe('components', () => {
           describe('FlightList', () => {
-            it('renders correctly', () => {
-              const flights = [
-                {
-                  id: 'sStfyLd2XArT7oUZPF3a',
-                  version: 0,
-                  departureAerodrome: {
-                    identification: 'LSZT',
-                    timezone: 'Europe/Zurich'
-                  },
-                  destinationAerodrome: null,
-                  blockOffTime: {
-                    toDate: () => Date.parse('2018-11-20 23:59 GMT+0100')
-                  },
-                  blockOnTime: null,
-                  takeOffTime: null,
-                  landingTime: null,
-                  pilot: {
-                    firstname: 'Max',
-                    lastname: 'Muster'
-                  }
+            const flights = [
+              {
+                id: 'sStfyLd2XArT7oUZPF3a',
+                version: 0,
+                departureAerodrome: {
+                  identification: 'LSZT',
+                  timezone: 'Europe/Zurich'
                 },
-                {
-                  id: 'sStfyLd2XArT7oUZPFDn',
-                  version: 1,
-                  departureAerodrome: {
-                    identification: 'LSZT',
-                    timezone: 'Europe/Zurich'
-                  },
-                  destinationAerodrome: {
-                    identification: 'LSZT',
-                    timezone: 'Europe/Zurich'
-                  },
-                  blockOffTime: {
-                    toDate: () => Date.parse('2018-11-20 10:00 GMT+0100')
-                  },
-                  blockOnTime: {
-                    toDate: () => Date.parse('2018-11-20 11:10 GMT+0100')
-                  },
-                  takeOffTime: {
-                    toDate: () => Date.parse('2018-11-20 10:10 GMT+0100')
-                  },
-                  landingTime: {
-                    toDate: () => Date.parse('2018-11-20 11:00 GMT+0100')
-                  },
-                  pilot: {
-                    firstname: 'Max',
-                    lastname: 'Muster'
-                  }
+                destinationAerodrome: null,
+                blockOffTime: {
+                  toDate: () => Date.parse('2018-11-20 23:59 GMT+0100')
                 },
-                {
-                  id: 'sStfyLd2XArT7oUZPFDa',
-                  version: 1,
-                  departureAerodrome: {
-                    identification: 'LSZT',
-                    timezone: 'Europe/Zurich'
-                  },
-                  destinationAerodrome: {
-                    identification: 'LSZT',
-                    timezone: 'Europe/Zurich'
-                  },
-                  blockOffTime: {
-                    toDate: () => Date.parse('2018-11-21 10:00 GMT+0100')
-                  },
-                  blockOnTime: {
-                    toDate: () => Date.parse('2018-11-21 11:10 GMT+0100')
-                  },
-                  takeOffTime: {
-                    toDate: () => Date.parse('2018-11-20 10:10 GMT+0100')
-                  },
-                  landingTime: {
-                    toDate: () => Date.parse('2018-11-20 11:00 GMT+0100')
-                  },
-                  pilot: {
-                    firstname: 'Hans',
-                    lastname: 'Meier'
-                  }
+                blockOnTime: null,
+                takeOffTime: null,
+                landingTime: null,
+                pilot: {
+                  firstname: 'Max',
+                  lastname: 'Muster'
                 }
-              ]
+              },
+              {
+                id: 'sStfyLd2XArT7oUZPFDn',
+                version: 1,
+                departureAerodrome: {
+                  identification: 'LSZT',
+                  timezone: 'Europe/Zurich'
+                },
+                destinationAerodrome: {
+                  identification: 'LSZT',
+                  timezone: 'Europe/Zurich'
+                },
+                blockOffTime: {
+                  toDate: () => Date.parse('2018-11-20 10:00 GMT+0100')
+                },
+                blockOnTime: {
+                  toDate: () => Date.parse('2018-11-20 11:10 GMT+0100')
+                },
+                takeOffTime: {
+                  toDate: () => Date.parse('2018-11-20 10:10 GMT+0100')
+                },
+                landingTime: {
+                  toDate: () => Date.parse('2018-11-20 11:00 GMT+0100')
+                },
+                pilot: {
+                  firstname: 'Max',
+                  lastname: 'Muster'
+                }
+              },
+              {
+                id: 'sStfyLd2XArT7oUZPFDa',
+                version: 1,
+                departureAerodrome: {
+                  identification: 'LSZT',
+                  timezone: 'Europe/Zurich'
+                },
+                destinationAerodrome: {
+                  identification: 'LSZT',
+                  timezone: 'Europe/Zurich'
+                },
+                blockOffTime: {
+                  toDate: () => Date.parse('2018-11-21 10:00 GMT+0100')
+                },
+                blockOnTime: {
+                  toDate: () => Date.parse('2018-11-21 11:10 GMT+0100')
+                },
+                takeOffTime: {
+                  toDate: () => Date.parse('2018-11-20 10:10 GMT+0100')
+                },
+                landingTime: {
+                  toDate: () => Date.parse('2018-11-20 11:00 GMT+0100')
+                },
+                pilot: {
+                  firstname: 'Hans',
+                  lastname: 'Meier'
+                }
+              }
+            ]
 
+            it('renders correctly', () => {
               const tree = renderIntl(
                 <FlightList
                   organization={{ id: 'my_org', roles: ['manager'] }}
+                  aircraft={{ id: 'my_aircraft' }}
+                  flights={flights}
+                  newestFlight={flights[0]}
+                  flightDeleteDialog={{ open: false }}
+                  pagination={{
+                    rowsCount: 25,
+                    page: 1,
+                    rowsPerPage: 10
+                  }}
+                  initFlightsList={() => {}}
+                  openFlightDeleteDialog={() => {}}
+                  closeFlightDeleteDialog={() => {}}
+                  deleteFlight={() => {}}
+                  setFlightsPage={() => {}}
+                />
+              ).toJSON()
+              expect(tree).toMatchSnapshot()
+            })
+
+            it('renders readonly if org readonly', () => {
+              const tree = renderIntl(
+                <FlightList
+                  organization={{ id: 'my_org', readonly: true, roles: [] }}
                   aircraft={{ id: 'my_aircraft' }}
                   flights={flights}
                   newestFlight={flights[0]}

--- a/src/routes/organizations/routes/aircraft/components/FlightList/__snapshots__/FlightList.spec.js.snap
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/__snapshots__/FlightList.spec.js.snap
@@ -510,3 +510,458 @@ Array [
   </div>,
 ]
 `;
+
+exports[`routes organizations routes aircraft components FlightList renders readonly if org readonly 1`] = `
+Array [
+  <div
+    className="FlightList-buttonsContainer-2"
+  />,
+  <div
+    className="FlightList-container-4"
+    data-cy="flights-container"
+  >
+    <div
+      className="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-rounded"
+      data-cy="preflight-panel"
+      data-id="sStfyLd2XArT7oUZPF3a"
+    >
+      <div
+        aria-disabled={false}
+        aria-expanded={false}
+        className="MuiButtonBase-root MuiExpansionPanelSummary-root"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <div
+          className="MuiExpansionPanelSummary-content FlightList-flightSummaryContent-7"
+        >
+          <div
+            className="FlightSummary-flightHeading-126"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1"
+            >
+              Von 
+              <span
+                className="FlightSummary-bold-128"
+              >
+                LSZT
+              </span>
+               — Max Muster
+            </p>
+            <span
+              className="MuiTypography-root FlightTag-tag-130 MuiTypography-body1"
+            >
+              Preflight
+            </span>
+          </div>
+          <p
+            className="MuiTypography-root FlightSummary-flightSecondaryHeading-127 MuiTypography-body1"
+          >
+            20.11.2018
+          </p>
+        </div>
+        <div
+          aria-disabled={false}
+          aria-hidden={true}
+          className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </div>
+      </div>
+      <div
+        className="MuiCollapse-container MuiCollapse-hidden"
+        style={
+          Object {
+            "minHeight": "0px",
+          }
+        }
+      >
+        <div
+          className="MuiCollapse-wrapper"
+        >
+          <div
+            className="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-rounded"
+      data-cy="flight-panel"
+      data-id="sStfyLd2XArT7oUZPFDn"
+    >
+      <div
+        aria-disabled={false}
+        aria-expanded={false}
+        className="MuiButtonBase-root MuiExpansionPanelSummary-root"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <div
+          className="MuiExpansionPanelSummary-content FlightList-flightSummaryContent-7"
+        >
+          <div
+            className="FlightSummary-flightHeading-126"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1"
+            >
+              Von 
+              <span
+                className="FlightSummary-bold-128"
+              >
+                LSZT
+              </span>
+               nach 
+              <span
+                className="FlightSummary-bold-128"
+              >
+                LSZT
+              </span>
+               — Max Muster
+            </p>
+          </div>
+          <p
+            className="MuiTypography-root FlightSummary-flightSecondaryHeading-127 MuiTypography-body1"
+          >
+            20.11.2018
+            ,
+             
+            10:00
+            -
+            11:10
+          </p>
+        </div>
+        <div
+          aria-disabled={false}
+          aria-hidden={true}
+          className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </div>
+      </div>
+      <div
+        className="MuiCollapse-container MuiCollapse-hidden"
+        style={
+          Object {
+            "minHeight": "0px",
+          }
+        }
+      >
+        <div
+          className="MuiCollapse-wrapper"
+        >
+          <div
+            className="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiPaper-root MuiPaper-elevation1 MuiExpansionPanel-root MuiExpansionPanel-rounded MuiPaper-rounded"
+      data-cy="flight-panel"
+      data-id="sStfyLd2XArT7oUZPFDa"
+    >
+      <div
+        aria-disabled={false}
+        aria-expanded={false}
+        className="MuiButtonBase-root MuiExpansionPanelSummary-root"
+        onBlur={[Function]}
+        onClick={[Function]}
+        onDragLeave={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseLeave={[Function]}
+        onMouseUp={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
+        role="button"
+        tabIndex={0}
+      >
+        <div
+          className="MuiExpansionPanelSummary-content FlightList-flightSummaryContent-7"
+        >
+          <div
+            className="FlightSummary-flightHeading-126"
+          >
+            <p
+              className="MuiTypography-root MuiTypography-body1"
+            >
+              Von 
+              <span
+                className="FlightSummary-bold-128"
+              >
+                LSZT
+              </span>
+               nach 
+              <span
+                className="FlightSummary-bold-128"
+              >
+                LSZT
+              </span>
+               — Hans Meier
+            </p>
+          </div>
+          <p
+            className="MuiTypography-root FlightSummary-flightSecondaryHeading-127 MuiTypography-body1"
+          >
+            21.11.2018
+            ,
+             
+            10:00
+            -
+            11:10
+          </p>
+        </div>
+        <div
+          aria-disabled={false}
+          aria-hidden={true}
+          className="MuiButtonBase-root MuiIconButton-root MuiExpansionPanelSummary-expandIcon MuiIconButton-edgeEnd"
+          onBlur={[Function]}
+          onDragLeave={[Function]}
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onKeyUp={[Function]}
+          onMouseDown={[Function]}
+          onMouseLeave={[Function]}
+          onMouseUp={[Function]}
+          onTouchEnd={[Function]}
+          onTouchMove={[Function]}
+          onTouchStart={[Function]}
+          role="button"
+          tabIndex={-1}
+        >
+          <span
+            className="MuiIconButton-label"
+          >
+            <svg
+              aria-hidden="true"
+              className="MuiSvgIcon-root"
+              focusable="false"
+              role="presentation"
+              viewBox="0 0 24 24"
+            >
+              <path
+                d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6z"
+              />
+            </svg>
+          </span>
+          <span
+            className="MuiTouchRipple-root"
+          />
+        </div>
+      </div>
+      <div
+        className="MuiCollapse-container MuiCollapse-hidden"
+        style={
+          Object {
+            "minHeight": "0px",
+          }
+        }
+      >
+        <div
+          className="MuiCollapse-wrapper"
+        >
+          <div
+            className="MuiCollapse-wrapperInner"
+          >
+            <div
+              role="region"
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className="MuiTablePagination-root"
+    >
+      <div
+        className="MuiToolbar-root MuiToolbar-regular MuiTablePagination-toolbar MuiToolbar-gutters"
+      >
+        <div
+          className="MuiTablePagination-spacer"
+        />
+        <span
+          className="MuiTypography-root MuiTablePagination-caption MuiTypography-caption MuiTypography-colorInherit"
+        >
+          11-20 of 25
+        </span>
+        <div
+          className="MuiTablePagination-actions"
+        >
+          <button
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                className="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M15.41 16.09l-4.58-4.59 4.58-4.59L14 5.5l-6 6 6 6z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
+          <button
+            className="MuiButtonBase-root MuiIconButton-root MuiIconButton-colorInherit"
+            disabled={false}
+            onBlur={[Function]}
+            onClick={[Function]}
+            onDragLeave={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseLeave={[Function]}
+            onMouseUp={[Function]}
+            onTouchEnd={[Function]}
+            onTouchMove={[Function]}
+            onTouchStart={[Function]}
+            tabIndex={0}
+            type="button"
+          >
+            <span
+              className="MuiIconButton-label"
+            >
+              <svg
+                aria-hidden="true"
+                className="MuiSvgIcon-root"
+                focusable="false"
+                role="presentation"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  d="M8.59 16.34l4.58-4.59-4.58-4.59L10 5.75l6 6-6 6z"
+                />
+              </svg>
+            </span>
+            <span
+              className="MuiTouchRipple-root"
+            />
+          </button>
+        </div>
+      </div>
+    </div>
+  </div>,
+]
+`;

--- a/src/routes/organizations/routes/aircraft/components/Techlog/Techlog.js
+++ b/src/routes/organizations/routes/aircraft/components/Techlog/Techlog.js
@@ -32,6 +32,8 @@ class Techlog extends React.Component {
     expanded: null
   }
 
+  hasWritePermissions = () => this.props.organization.readonly !== true
+
   componentDidMount() {
     const { organization, aircraft, initTechlog, showOnlyOpen } = this.props
     initTechlog(organization.id, aircraft.id, showOnlyOpen)
@@ -71,13 +73,15 @@ class Techlog extends React.Component {
 
     return (
       <React.Fragment>
-        <Button
-          variant="contained"
-          color="primary"
-          onClick={this.handleCreateClick}
-        >
-          <FormattedMessage id="aircraftdetail.techlog.create" />
-        </Button>
+        {this.hasWritePermissions() && (
+          <Button
+            variant="contained"
+            color="primary"
+            onClick={this.handleCreateClick}
+          >
+            <FormattedMessage id="aircraftdetail.techlog.create" />
+          </Button>
+        )}
         <div className={classes.container}>
           {techlog.length > 0 ? this.renderEntries() : this.renderNoEntries()}
           {techlog.length > 0 && pagination && (

--- a/src/routes/start/containers/StartPageContainer.js
+++ b/src/routes/start/containers/StartPageContainer.js
@@ -5,9 +5,11 @@ import { getOrganization } from '../../../util/getFromState'
 const getSelectedOrganization = state => {
   const currentUser = state.firestore.data.currentUser
 
-  // not yet loaded
   if (!currentUser) {
-    return undefined
+    if (state.firebase.auth.uid === 'readonly') {
+      return null
+    }
+    return undefined // not yet loaded
   }
 
   return currentUser.selectedOrganization

--- a/src/routes/start/containers/StartPageContainer.spec.js
+++ b/src/routes/start/containers/StartPageContainer.spec.js
@@ -39,6 +39,11 @@ describe('routes', () => {
               app: {
                 organizations: [{ id: 'my_org' }]
               }
+            },
+            firebase: {
+              auth: {
+                uid: 'sasf502'
+              }
             }
           })
 
@@ -71,6 +76,9 @@ describe('routes', () => {
               data: {
                 // no `currentUser` here
               }
+            },
+            firebase: {
+              auth: {}
             }
           })
 

--- a/src/shapes/organization.js
+++ b/src/shapes/organization.js
@@ -3,5 +3,6 @@ import PropTypes from 'prop-types'
 export default PropTypes.shape({
   id: PropTypes.string.isRequired,
   roles: PropTypes.arrayOf(PropTypes.string).isRequired,
-  lockDate: PropTypes.object
+  lockDate: PropTypes.object,
+  readonly: PropTypes.bool // (for ramp check view) will be removed once all regular users have at least the 'pilot' role
 })

--- a/src/util/getAuthQueryToken.js
+++ b/src/util/getAuthQueryToken.js
@@ -1,0 +1,23 @@
+const PATTERN = /.*-\b[0-9a-f]{8}\b-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-\b[0-9a-f]{12}\b/
+
+const getAuthQueryToken = location => {
+  if (location.state && location.state.queryToken) {
+    return location.state.queryToken
+  }
+
+  const query = new URLSearchParams(location.search)
+  const queryToken = query.get('t')
+
+  if (PATTERN.test(queryToken)) {
+    const orgId = queryToken.substr(0, queryToken.length - 37)
+    const token = queryToken.substr(queryToken.length - 36)
+    return {
+      orgId,
+      token
+    }
+  }
+
+  return null
+}
+
+export default getAuthQueryToken

--- a/src/util/getAuthQueryToken.spec.js
+++ b/src/util/getAuthQueryToken.spec.js
@@ -1,0 +1,42 @@
+import getAuthQueryToken from './getAuthQueryToken'
+
+describe('util', () => {
+  describe('getAuthQueryToken', () => {
+    it('should return null if no token in state or search params', () => {
+      const location = {}
+      expect(getAuthQueryToken(location)).toEqual(null)
+    })
+
+    it('should return token from location state', () => {
+      const location = {
+        state: {
+          queryToken: {
+            token: '4ab43049-64ac-435e-92c7-23daa066d4a5',
+            orgId: 'mfgt'
+          }
+        }
+      }
+      expect(getAuthQueryToken(location)).toEqual({
+        token: '4ab43049-64ac-435e-92c7-23daa066d4a5',
+        orgId: 'mfgt'
+      })
+    })
+
+    it('should return token from search params if not in state', () => {
+      const location = {
+        search: '?t=mfgt-4ab43049-64ac-435e-92c7-23daa066d4a5'
+      }
+      expect(getAuthQueryToken(location)).toEqual({
+        token: '4ab43049-64ac-435e-92c7-23daa066d4a5',
+        orgId: 'mfgt'
+      })
+    })
+
+    it('should return null if search param not valid', () => {
+      const location = {
+        search: '?t=mfgt-asdf'
+      }
+      expect(getAuthQueryToken(location)).toEqual(null)
+    })
+  })
+})


### PR DESCRIPTION
- Can, for instance, be useful for ramp checks (scan a QR code
  representing the sharing link for quick and easy access)
- Can be enabled for any organization by setting `readonlyAccessEnabled`
  to true and generating a `readonlyAccessToken` property containing
  a UUID (not yet possible in the UI)
- Sharing link will have a `t` search param in the format
  `{orgId}-{readonlyAccessToken}`
  (e.g. `?t=mfgt-333f10cf-ed86-43ae-881f-c4db5ebd8b73`)
- If the `t` search param is present, the readonly login will be
  performed. The actual link can point to any route within the
  organization, for instance to a certain aircraft:
  /organizations/mfgt/aircrafts/wTNNQVk?t=mfgt-333f10cf-ed86-43ae-881f-c4db5ebd8b73