### PR TITLE
Improve layout of flight details on mobile devices

### DIFF
--- a/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.js
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/FlightDetails.js
@@ -23,7 +23,7 @@ const FlightDetails = ({ aircraft, flight }) => {
     <div>
       <Grid container>
         <Grid item xs={12} container>
-          <Grid item xs={12} sm={4}>
+          <Grid item xs={12} md={4}>
             {renderField(
               'date',
               formatDate(
@@ -33,15 +33,15 @@ const FlightDetails = ({ aircraft, flight }) => {
               intl
             )}
           </Grid>
-          <Grid item xs={6} sm={4}>
+          <Grid item xs={6} md={4}>
             {renderField('pilot', getMemberName(flight.pilot), intl)}
           </Grid>
-          <Grid item xs={6} sm={4}>
+          <Grid item xs={6} md={4}>
             {renderField('instructor', getMemberName(flight.instructor), intl)}
           </Grid>
         </Grid>
         <Grid item xs={12} container>
-          <Grid item xs={12} sm={4}>
+          <Grid item xs={12} md={4}>
             {renderField(
               'departureaerodrome',
               getAerodromeName(flight.departureAerodrome),
@@ -50,7 +50,7 @@ const FlightDetails = ({ aircraft, flight }) => {
           </Grid>
           {flight.version > 0 && (
             <>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={6} md={4}>
                 {renderField(
                   'blockofftime',
                   formatTimeWithUtc(
@@ -60,7 +60,7 @@ const FlightDetails = ({ aircraft, flight }) => {
                   intl
                 )}
               </Grid>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={6} md={4}>
                 {renderField(
                   'takeofftime',
                   formatTimeWithUtc(
@@ -76,14 +76,14 @@ const FlightDetails = ({ aircraft, flight }) => {
         {flight.version > 0 && (
           <>
             <Grid item xs={12} container>
-              <Grid item xs={12} sm={4}>
+              <Grid item xs={12} md={4}>
                 {renderField(
                   'destinationaerodrome',
                   getAerodromeName(flight.destinationAerodrome),
                   intl
                 )}
               </Grid>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={6} md={4}>
                 {renderField(
                   'blockontime',
                   formatTimeWithUtc(
@@ -93,7 +93,7 @@ const FlightDetails = ({ aircraft, flight }) => {
                   intl
                 )}
               </Grid>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={6} md={4}>
                 {renderField(
                   'landingtime',
                   formatTimeWithUtc(
@@ -107,10 +107,10 @@ const FlightDetails = ({ aircraft, flight }) => {
           </>
         )}
         <Grid item xs={12} container>
-          <Grid item xs={12} sm={4}>
+          <Grid item xs={12} md={4}>
             {renderField('nature', getFlightNature(flight.nature, intl), intl)}
           </Grid>
-          <Grid item xs={12} sm={4}>
+          <Grid item xs={12} md={4}>
             {renderField(
               'fueluplift',
               getFuel(
@@ -121,22 +121,22 @@ const FlightDetails = ({ aircraft, flight }) => {
               intl
             )}
           </Grid>
-          <Grid item xs={12} sm={4}>
-            <Grid item xs={12} sm={4}>
+          <Grid item xs={12} md={4}>
+            <Grid item xs={12} md={4}>
               {renderField('oiluplift', getOil(flight.oilUplift), intl)}
             </Grid>
           </Grid>
         </Grid>
         <Grid item xs={12} container>
           {flight.version > 0 && (
-            <Grid item xs={12} sm={4}>
+            <Grid item xs={12} md={4}>
               {renderField('landings', flight.landings, intl)}
             </Grid>
           )}
-          <Grid item xs={12} sm={4}>
+          <Grid item xs={12} md={4}>
             {renderField('personsonboard', flight.personsOnBoard || '-', intl)}
           </Grid>
-          <Grid item xs={12} sm={8}>
+          <Grid item xs={12} md={8}>
             {flight.remarks &&
               renderField('remarks', flight.remarks || '-', intl, true)}
           </Grid>
@@ -144,14 +144,14 @@ const FlightDetails = ({ aircraft, flight }) => {
         {flight.version > 0 && (
           <>
             <Grid item xs={12} container>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={12} md={4}>
                 {renderField(
                   'flighthours_time',
                   getTimeDiff(flight.takeOffTime, flight.landingTime),
                   intl
                 )}
               </Grid>
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={12} md={4}>
                 {renderField(
                   'blockhours',
                   getTimeDiff(flight.blockOffTime, flight.blockOnTime),
@@ -164,7 +164,7 @@ const FlightDetails = ({ aircraft, flight }) => {
         {flight.version > 0 && flight.counters && (
           <Grid item xs={12} container>
             {flight.counters.flightTimeCounter && (
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={12} md={4}>
                 {aircraft.settings.flightTimeCounterEnabled &&
                   renderField(
                     'flighthours_counter',
@@ -177,7 +177,7 @@ const FlightDetails = ({ aircraft, flight }) => {
               </Grid>
             )}
             {flight.counters.engineTimeCounter && (
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={12} md={4}>
                 {aircraft.settings.engineHoursCounterEnabled &&
                   renderField(
                     'enginehours',
@@ -190,7 +190,7 @@ const FlightDetails = ({ aircraft, flight }) => {
               </Grid>
             )}
             {flight.counters.engineTachCounter && (
-              <Grid item xs={6} sm={4}>
+              <Grid item xs={12} md={4}>
                 {aircraft.settings.engineTachHoursCounterEnabled &&
                   renderField(
                     'enginetachhours',
@@ -207,7 +207,7 @@ const FlightDetails = ({ aircraft, flight }) => {
       </Grid>
       {typeof flight.preflightCheck === 'boolean' && (
         <Grid item xs={12} container>
-          <Grid item xs={12} sm={8}>
+          <Grid item xs={12} md={8}>
             <InputLabel shrink>
               {intl.formatMessage({ id: 'flightlist.preflightcheck' })}
             </InputLabel>
@@ -217,7 +217,7 @@ const FlightDetails = ({ aircraft, flight }) => {
       )}
       {flight.troublesObservations && (
         <Grid item xs={12} container>
-          <Grid item xs={12} sm={8}>
+          <Grid item xs={12} md={8}>
             {flight.troublesObservations === 'nil' ? (
               renderField('troublesobservations', 'NIL', intl)
             ) : (

--- a/src/routes/organizations/routes/aircraft/components/FlightList/__snapshots__/FlightDetails.spec.js.snap
+++ b/src/routes/organizations/routes/aircraft/components/FlightList/__snapshots__/FlightDetails.spec.js.snap
@@ -9,7 +9,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -40,7 +40,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -71,7 +71,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -106,7 +106,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -137,7 +137,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -168,7 +168,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -203,7 +203,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -234,7 +234,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -265,7 +265,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -300,7 +300,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -331,7 +331,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -362,10 +362,10 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
         >
           <div
             className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -401,7 +401,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -432,7 +432,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -463,7 +463,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -522,7 +522,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -553,7 +553,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -588,10 +588,10 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       />
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -627,7 +627,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
@@ -652,7 +652,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -857,7 +857,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -888,7 +888,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -919,7 +919,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -954,7 +954,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -985,7 +985,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1016,7 +1016,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1051,7 +1051,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1082,7 +1082,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1113,7 +1113,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1148,7 +1148,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1179,7 +1179,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1210,10 +1210,10 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
         >
           <div
             className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1249,7 +1249,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1280,7 +1280,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1311,7 +1311,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1370,7 +1370,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1401,7 +1401,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1436,7 +1436,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1467,7 +1467,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       />
     </div>
   </div>
@@ -1475,7 +1475,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
@@ -1500,7 +1500,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1705,7 +1705,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1736,7 +1736,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1767,7 +1767,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1802,7 +1802,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1833,7 +1833,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1864,7 +1864,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1899,7 +1899,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1930,7 +1930,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1961,7 +1961,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -1996,7 +1996,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2027,7 +2027,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2058,10 +2058,10 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
         >
           <div
             className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2097,7 +2097,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2128,7 +2128,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2159,7 +2159,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2218,7 +2218,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2249,7 +2249,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2284,7 +2284,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2315,7 +2315,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2351,7 +2351,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
@@ -2376,7 +2376,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2581,7 +2581,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2612,7 +2612,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2643,7 +2643,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2678,7 +2678,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2713,7 +2713,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2744,7 +2744,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2775,10 +2775,10 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
         >
           <div
             className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2814,7 +2814,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2845,7 +2845,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2905,7 +2905,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
@@ -2941,7 +2941,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -2972,7 +2972,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3003,7 +3003,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3038,7 +3038,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3069,7 +3069,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3100,7 +3100,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3135,7 +3135,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3166,7 +3166,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3197,7 +3197,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3232,7 +3232,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3263,7 +3263,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3294,10 +3294,10 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
         >
           <div
             className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3333,7 +3333,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3364,7 +3364,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3395,7 +3395,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3454,7 +3454,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3485,7 +3485,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3520,7 +3520,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3551,7 +3551,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3587,7 +3587,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
@@ -3612,7 +3612,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3817,7 +3817,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3848,7 +3848,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3879,7 +3879,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3914,7 +3914,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3945,7 +3945,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -3976,7 +3976,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4011,7 +4011,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4042,7 +4042,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4073,7 +4073,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4108,7 +4108,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4139,7 +4139,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4170,10 +4170,10 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
-          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+          className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
         >
           <div
             className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4209,7 +4209,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4240,7 +4240,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4271,7 +4271,7 @@ exports[`routes organizations routes aircraft components FlightList FlightDetail
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4330,7 +4330,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4361,7 +4361,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4396,7 +4396,7 @@ remarks"
       className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
     >
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4427,7 +4427,7 @@ remarks"
         </div>
       </div>
       <div
-        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-6 MuiGrid-grid-sm-4"
+        className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-4"
       >
         <div
           className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"
@@ -4463,7 +4463,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <label
         className="MuiFormLabel-root MuiInputLabel-root MuiInputLabel-animated MuiInputLabel-shrink"
@@ -4488,7 +4488,7 @@ remarks"
     className="MuiGrid-root MuiGrid-container MuiGrid-item MuiGrid-grid-xs-12"
   >
     <div
-      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-sm-8"
+      className="MuiGrid-root MuiGrid-item MuiGrid-grid-xs-12 MuiGrid-grid-md-8"
     >
       <div
         className="MuiFormControl-root MuiTextField-root MuiFormControl-marginNormal MuiFormControl-fullWidth"


### PR DESCRIPTION
Line breaks should occur earlier, because some of the field labels
are quite long and otherwise overlap the field contents.