### PR TITLE
Take flight defaults from aircraft settings

### DIFF
--- a/functions/aircraft/saveFlight.function.js
+++ b/functions/aircraft/saveFlight.function.js
@@ -180,10 +180,7 @@ const saveFlight = functions.https.onCall(
 
     const fuelUplift =
       typeof data.fuelUplift === 'number' ? data.fuelUplift / 100 : null
-    const fuelType =
-      typeof fuelUplift === 'number' && fuelUplift > 0
-        ? data.fuelType.value
-        : null
+    const fuelType = data.fuelType ? data.fuelType.value : null
 
     const oilUplift =
       typeof data.oilUplift === 'number' ? data.oilUplift / 100 : null

--- a/src/routes/organizations/routes/aircraft/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.js
@@ -233,6 +233,17 @@ export function* createFlight({
   }
 }
 
+const getFlightDefaults = aircraftSettings => ({
+  ...aircraftSettings.flightDefaults,
+  fuelType:
+    aircraftSettings.flightDefaults && aircraftSettings.flightDefaults.fuelType
+      ? toFuelTypeOption(
+          aircraftSettings,
+          aircraftSettings.flightDefaults.fuelType
+        )
+      : null
+})
+
 export function* initCreateFlightDialog({
   payload: { organizationId, aircraftId }
 }) {
@@ -270,6 +281,7 @@ export function* initCreateFlightDialog({
   }
 
   const data = {
+    ...getFlightDefaults(aircraftSettings),
     date: moment().format('YYYY-MM-DD'),
     pilot: getMemberOption(currentMember),
     departureAerodrome: departureAerodrome

--- a/src/routes/organizations/routes/aircraft/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/module/sagas.spec.js
@@ -605,7 +605,8 @@ describe('routes', () => {
                 blockOffTime: endOfToday,
                 takeOffTime: null,
                 landingTime: null,
-                blockOnTime: null
+                blockOnTime: null,
+                fuelType: null
               }
 
               return expectSaga(sagas.initCreateFlightDialog, action)
@@ -657,7 +658,81 @@ describe('routes', () => {
                 blockOffTime: endOfToday,
                 takeOffTime: null,
                 landingTime: null,
-                blockOnTime: null
+                blockOnTime: null,
+                fuelType: null
+              }
+
+              return expectSaga(sagas.initCreateFlightDialog, action)
+                .provide([
+                  [call(getCurrentMember), currentMember],
+                  [call(getLastFlight, orgId, aircraftId), lastFlight],
+                  [
+                    call(sagas.getDestinationAerodrome, lastFlight),
+                    destinationAerodrome
+                  ],
+                  [
+                    select(sagas.aircraftSettingsSelector, aircraftId),
+                    aircraftSettings
+                  ]
+                ])
+                .put(
+                  actions.setInitialCreateFlightDialogData(
+                    expectedDefaultValues,
+                    expectedVisibleFields(false, false, false),
+                    expectedEditableFields
+                  )
+                )
+                .run()
+            })
+
+            it('should set default values from aircraft settings', () => {
+              const aircraftSettings = {
+                flightTimeCounterEnabled: false,
+                engineHoursCounterEnabled: false,
+                engineTachHoursCounterEnabled: false,
+                flightDefaults: {
+                  nature: 'vp',
+                  personsOnBoard: 1,
+                  fuelUplift: 0,
+                  fuelType: 'jet_a1',
+                  oilUplift: 0
+                },
+                fuelTypes: [
+                  {
+                    name: 'jet_a1',
+                    description: 'Jet A1'
+                  }
+                ]
+              }
+
+              const expectedDefaultValues = {
+                date: today,
+                pilot: {
+                  value: 'memberid',
+                  label: 'Müller Max'
+                },
+                departureAerodrome: {
+                  value: 'aerodromeid',
+                  label: 'LSZT (Lommis)',
+                  timezone: 'Europe/Zurich'
+                },
+                counters: {
+                  flights: { start: 123 },
+                  flightHours: { start: 10250 },
+                  landings: { start: 2357 }
+                },
+                blockOffTime: endOfToday,
+                takeOffTime: null,
+                landingTime: null,
+                blockOnTime: null,
+                nature: 'vp',
+                personsOnBoard: 1,
+                fuelUplift: 0,
+                fuelType: {
+                  value: 'jet_a1',
+                  label: 'Jet A1'
+                },
+                oilUplift: 0
               }
 
               return expectSaga(sagas.initCreateFlightDialog, action)


### PR DESCRIPTION
Flight defaults can now be set per aircraft in the settings property
(add a map called `flightDefaults`).
By now, the defaults have to be set directly in the database, it's not
possible to define them in the UI yet.