### PR TITLE
Only allow updating the `deleted` field of an organization

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -61,7 +61,7 @@ service cloud.firestore {
 
     match /organizations/{organization} {
       allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);
-      allow update: if isOrgManager(database, organization);
+      allow update: if isOrgManager(database, organization) && affectsOnly(["deleted"]);
 
       match /members/{member} {
         allow read: if isOrgMember(database, organization) || isReadonlyOrgUser(organization);


### PR DESCRIPTION
Primarily it must be impossible to write to the limits object
in an organization. But actually, the only field that needs write
access is the `deleted` flag.