### PR TITLE
Implicitly deactivate techlog feature if disabled on current plan

### DIFF
--- a/functions/aircraft/updateAircraftSetting.function.js
+++ b/functions/aircraft/updateAircraftSetting.function.js
@@ -1,0 +1,66 @@
+const functions = require('firebase-functions')
+const admin = require('firebase-admin')
+const getMemberByUid = require('../utils/getMemberByUid')
+const requireRole = require('../utils/requireRole')
+const getOrganizationLimits = require('../utils/getOrganizationLimits')
+
+// Prevent firebase from initializing twice
+try {
+  admin.initializeApp(functions.config().firebase)
+  // eslint-disable-next-line no-empty
+} catch (e) {}
+
+const db = admin.firestore()
+
+const ensureManager = async (organizationId, context) => {
+  const member = await getMemberByUid(db, organizationId, context.auth.uid)
+  requireRole(member, ['manager'])
+}
+
+const VALIDATORS = {
+  techlogEnabled: (name, value, limits, organizationId) => {
+    if (limits.techlogDisabled === true) {
+      return `Techlog feature disabled on organization ${organizationId}`
+    }
+  }
+}
+
+const validate = async (organizationId, name, value) => {
+  if (VALIDATORS[name]) {
+    const limits = await getOrganizationLimits(db, organizationId)
+    const error = VALIDATORS[name](name, value, limits, organizationId)
+    if (error) {
+      throw new Error(error)
+    }
+  }
+}
+
+const updateAircraftSetting = functions.https.onCall(async (data, context) => {
+  const { organizationId, aircraftId, name, value } = data
+
+  await ensureManager(organizationId, context)
+  await validate(organizationId, name, value)
+
+  const aircraft = await db
+    .collection('organizations')
+    .doc(organizationId)
+    .collection('aircrafts')
+    .doc(aircraftId)
+    .get()
+
+  if (
+    !aircraft ||
+    aircraft.exists !== true ||
+    aircraft.get('deleted') === true
+  ) {
+    throw new Error(
+      `Cannot update setting of aircraft that does not exist (org id: ${organizationId}, aircraft id: ${aircraftId})`
+    )
+  }
+
+  await aircraft.ref.update({
+    [`settings.${name}`]: value
+  })
+})
+
+exports.updateAircraftSetting = updateAircraftSetting

--- a/src/routes/organizations/routes/aircraft/containers/AircraftDetailContainer.spec.js
+++ b/src/routes/organizations/routes/aircraft/containers/AircraftDetailContainer.spec.js
@@ -25,6 +25,9 @@ describe('routes', () => {
                     stsTokenManager: {
                       accessToken: 'my-access-token'
                     }
+                  },
+                  profile: {
+                    selectedOrganization: 'my_org'
                   }
                 },
                 main: {

--- a/src/routes/organizations/routes/aircraft/routes/settings/components/AircraftSettings/AircraftSettings.spec.js
+++ b/src/routes/organizations/routes/aircraft/routes/settings/components/AircraftSettings/AircraftSettings.spec.js
@@ -100,6 +100,16 @@ describe('routes', () => {
 
                 it('renders aircraft settings when everything is loaded', () => {
                   const store = configureStore()({
+                    firebase: {
+                      profile: {
+                        selectedOrganization: 'org_id'
+                      }
+                    },
+                    main: {
+                      app: {
+                        organizations: [{ id: 'org_id' }]
+                      }
+                    },
                     firestore: {
                       data: {
                         organizationAircrafts: {

--- a/src/routes/organizations/routes/aircraft/routes/settings/components/AircraftSettingsPage/AircraftSettingsPage.spec.js
+++ b/src/routes/organizations/routes/aircraft/routes/settings/components/AircraftSettingsPage/AircraftSettingsPage.spec.js
@@ -20,7 +20,9 @@ describe('routes', () => {
                         isEmpty: false,
                         email: 'test@opendigital.ch'
                       },
-                      profile: {}
+                      profile: {
+                        selectedOrganization: 'my_org'
+                      }
                     },
                     main: {
                       app: {

--- a/src/routes/organizations/routes/aircraft/routes/settings/containers/AircraftSettingsContainer.spec.js
+++ b/src/routes/organizations/routes/aircraft/routes/settings/containers/AircraftSettingsContainer.spec.js
@@ -22,7 +22,11 @@ describe('routes', () => {
                   jest.resetAllMocks()
 
                   const state = {
-                    firebase: {},
+                    firebase: {
+                      profile: {
+                        selectedOrganization: 'my_org'
+                      }
+                    },
                     main: {
                       app: {
                         organizations: [{ id: 'my_org' }]

--- a/src/routes/organizations/routes/aircraft/routes/settings/containers/FuelTypesContainer.spec.js
+++ b/src/routes/organizations/routes/aircraft/routes/settings/containers/FuelTypesContainer.spec.js
@@ -22,6 +22,16 @@ describe('routes', () => {
                   jest.resetAllMocks()
 
                   const state = {
+                    firebase: {
+                      profile: {
+                        selectedOrganization: 'org_id'
+                      }
+                    },
+                    main: {
+                      app: {
+                        organizations: [{ id: 'org_id' }]
+                      }
+                    },
                     firestore: {
                       data: {
                         organizationAircrafts: {

--- a/src/routes/organizations/routes/aircraft/routes/settings/module/sagas.js
+++ b/src/routes/organizations/routes/aircraft/routes/settings/module/sagas.js
@@ -90,11 +90,12 @@ export function* updateSetting({
 }) {
   yield put(actions.setSettingSubmitting(name, true))
 
-  yield call(
-    updateDoc,
-    ['organizations', organizationId, 'aircrafts', aircraftId],
-    { [`settings.${name}`]: value }
-  )
+  yield call(callFunction, 'updateAircraftSetting', {
+    organizationId,
+    aircraftId,
+    name,
+    value
+  })
 
   yield put(fetchAircrafts(organizationId))
   yield put(actions.setSettingSubmitting(name, false))

--- a/src/routes/organizations/routes/aircraft/routes/settings/module/sagas.spec.js
+++ b/src/routes/organizations/routes/aircraft/routes/settings/module/sagas.spec.js
@@ -174,19 +174,21 @@ describe('routes', () => {
                   return expectSaga(sagas.updateSetting, action)
                     .provide([
                       [
-                        call(
-                          updateDoc,
-                          ['organizations', orgId, 'aircrafts', aircraftId],
-                          { 'settings.techlogEnabled': true }
-                        )
+                        call(callFunction, 'updateAircraftSetting', {
+                          organizationId: orgId,
+                          aircraftId,
+                          name: 'techlogEnabled',
+                          value: true
+                        })
                       ]
                     ])
                     .put(actions.setSettingSubmitting('techlogEnabled', true))
-                    .call(
-                      updateDoc,
-                      ['organizations', orgId, 'aircrafts', aircraftId],
-                      { 'settings.techlogEnabled': true }
-                    )
+                    .call(callFunction, 'updateAircraftSetting', {
+                      organizationId: orgId,
+                      aircraftId,
+                      name: 'techlogEnabled',
+                      value: true
+                    })
                     .put(fetchAircrafts(orgId))
                     .put(actions.setSettingSubmitting('techlogEnabled', false))
                     .run()

--- a/src/routes/organizations/routes/aircraft/util/flightDialogUtils.js
+++ b/src/routes/organizations/routes/aircraft/util/flightDialogUtils.js
@@ -21,32 +21,12 @@ export const techlogEntryStatus = intl =>
 
 export const aircraftSettings = (state, aircraftId) => {
   const aircraftSettings = getAircraft(state, aircraftId).settings
-  if (aircraftSettings) {
-    const fuelTypes = aircraftSettings.fuelTypes || []
-    const fuelTypeOptions = fuelTypes.map(fuelType =>
-      getFuelTypeOption(fuelType)
-    )
-    return {
-      fuelTypes: fuelTypeOptions,
-      flightTimeCounterEnabled:
-        aircraftSettings.flightTimeCounterEnabled === true,
-      flightTimeCounterFractionDigits:
-        aircraftSettings.flightTimeCounterFractionDigits,
-      engineHoursCounterEnabled:
-        aircraftSettings.engineHoursCounterEnabled === true,
-      engineHoursCounterFractionDigits:
-        aircraftSettings.engineHoursCounterFractionDigits,
-      engineTachHoursCounterEnabled:
-        aircraftSettings.engineTachHoursCounterEnabled === true,
-      engineTachHoursCounterFractionDigits:
-        aircraftSettings.engineTachHoursCounterFractionDigits,
-      techlogEnabled: aircraftSettings.techlogEnabled === true,
-      techlogSignatureEnabled:
-        aircraftSettings.techlogSignatureEnabled === true,
-      lockDate: aircraftSettings.lockDate
-        ? aircraftSettings.lockDate.toDate()
-        : null
-    }
+  const fuelTypeOptions = aircraftSettings.fuelTypes.map(fuelType =>
+    getFuelTypeOption(fuelType)
+  )
+  return {
+    ...aircraftSettings,
+    fuelTypes: fuelTypeOptions
   }
 }
 

--- a/src/util/getFromState.js
+++ b/src/util/getFromState.js
@@ -26,6 +26,33 @@ export const getOrganization = (state, organizationId) => {
   return undefined // still loading
 }
 
+const aircraftSettings = (aircraftSettings = {}, organization = {}) => {
+  const limits = organization.limits || {}
+
+  return {
+    fuelTypes: aircraftSettings.fuelTypes || [],
+    flightTimeCounterEnabled:
+      aircraftSettings.flightTimeCounterEnabled === true,
+    flightTimeCounterFractionDigits:
+      aircraftSettings.flightTimeCounterFractionDigits,
+    engineHoursCounterEnabled:
+      aircraftSettings.engineHoursCounterEnabled === true,
+    engineHoursCounterFractionDigits:
+      aircraftSettings.engineHoursCounterFractionDigits,
+    engineTachHoursCounterEnabled:
+      aircraftSettings.engineTachHoursCounterEnabled === true,
+    engineTachHoursCounterFractionDigits:
+      aircraftSettings.engineTachHoursCounterFractionDigits,
+    techlogEnabled:
+      aircraftSettings.techlogEnabled === true &&
+      limits.techlogDisabled !== true,
+    techlogSignatureEnabled: aircraftSettings.techlogSignatureEnabled === true,
+    lockDate: aircraftSettings.lockDate
+      ? aircraftSettings.lockDate.toDate()
+      : null
+  }
+}
+
 export const getAircraft = (state, aircraftId) => {
   const organizationAircrafts = state.firestore.data.organizationAircrafts
   if (organizationAircrafts) {
@@ -45,9 +72,11 @@ export const getAircraft = (state, aircraftId) => {
       aircraft.counters.techlogEntries = techlogEntriesCount
       aircraft.counters.flightsTotal = flightsTotalCount
 
-      if (!aircraft.settings) {
-        aircraft.settings = {}
-      }
+      const organization = getOrganization(
+        state,
+        state.firebase.profile.selectedOrganization
+      )
+      aircraft.settings = aircraftSettings(aircraft.settings, organization)
 
       return aircraft
     }

--- a/src/util/getFromState.spec.js
+++ b/src/util/getFromState.spec.js
@@ -131,6 +131,16 @@ describe('util', () => {
 
       it('should return found aircraft with default counters', () => {
         const state = {
+          firebase: {
+            profile: {
+              selectedOrganization: 'org_id'
+            }
+          },
+          main: {
+            app: {
+              organizations: [{ id: 'org_id' }]
+            }
+          },
           firestore: {
             data: {
               organizationAircrafts: {
@@ -156,12 +166,33 @@ describe('util', () => {
             techlogEntries: 0,
             flightsTotal: 0
           },
-          settings: {}
+          settings: {
+            engineHoursCounterEnabled: false,
+            engineHoursCounterFractionDigits: undefined,
+            engineTachHoursCounterEnabled: false,
+            engineTachHoursCounterFractionDigits: undefined,
+            flightTimeCounterEnabled: false,
+            flightTimeCounterFractionDigits: undefined,
+            fuelTypes: [],
+            lockDate: null,
+            techlogEnabled: false,
+            techlogSignatureEnabled: false
+          }
         })
       })
 
       it('should return found aircraft with counters from latest flight', () => {
         const state = {
+          firebase: {
+            profile: {
+              selectedOrganization: 'org_id'
+            }
+          },
+          main: {
+            app: {
+              organizations: [{ id: 'org_id' }]
+            }
+          },
           firestore: {
             data: {
               organizationAircrafts: {
@@ -195,12 +226,33 @@ describe('util', () => {
             techlogEntries: 0,
             flightsTotal: 0
           },
-          settings: {}
+          settings: {
+            engineHoursCounterEnabled: false,
+            engineHoursCounterFractionDigits: undefined,
+            engineTachHoursCounterEnabled: false,
+            engineTachHoursCounterFractionDigits: undefined,
+            flightTimeCounterEnabled: false,
+            flightTimeCounterFractionDigits: undefined,
+            fuelTypes: [],
+            lockDate: null,
+            techlogEnabled: false,
+            techlogSignatureEnabled: false
+          }
         })
       })
 
       it('should return techlog entries and total flights count from aircraft counters object', () => {
         const state = {
+          firebase: {
+            profile: {
+              selectedOrganization: 'org_id'
+            }
+          },
+          main: {
+            app: {
+              organizations: [{ id: 'org_id' }]
+            }
+          },
           firestore: {
             data: {
               organizationAircrafts: {
@@ -238,7 +290,18 @@ describe('util', () => {
             techlogEntries: 32,
             flightsTotal: 98
           },
-          settings: {}
+          settings: {
+            engineHoursCounterEnabled: false,
+            engineHoursCounterFractionDigits: undefined,
+            engineTachHoursCounterEnabled: false,
+            engineTachHoursCounterFractionDigits: undefined,
+            flightTimeCounterEnabled: false,
+            flightTimeCounterFractionDigits: undefined,
+            fuelTypes: [],
+            lockDate: null,
+            techlogEnabled: false,
+            techlogSignatureEnabled: false
+          }
         })
       })
     })


### PR DESCRIPTION
The techlog shouldn't be active if the feature isn't activated in
the current plan of the organization -> even if it's actually
enabled in the aircraft settings